### PR TITLE
Skip version bump if commit already has tag (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,22 @@ jobs:
 * **REPO_OWNER** ***(required)*** - Required to target the repo to tag.
 * **DEFAULT_BUMP** *(optional)* - Which type of bump to use when none explicitly provided (default: `minor`).
 
-*NOTE:* This creates a [lightweight tag](https://developer.github.com/v3/git/refs/#create-a-reference)
+> ***Note:*** This action creates a [lightweight tag](https://developer.github.com/v3/git/refs/#create-a-reference).
 
 ### Bumping
 
-Any commit message with `#major`, `#minor`, or `#patch` will trigger the respective version bump. If two or more are present, the biggest one will take preference.
+**Manual Bumping:** Any commit message that includes `#major`, `#minor`, or `#patch` will trigger the respective version bump. If two or more are present, the highest-ranking one will take precedence.
 
-This **will not** attempt to tag a commit that has already has a tag.
+**Automatic Bumping:** If no `#major`, `#minor` or `#patch` tag is contained in the commit messages, it will bump whichever `DEFAULT_BUMP` is set to (which is `minor` by default).
+
+> ***Note:*** This action **will not** bump the tag if the `HEAD` commit has already been tagged.
 
 ### Workflow
 
 * Add this action to your repo
 * Commit some changes
 * Either push to master or open a PR
-* On push(or merge) to master, Action will:
+* On push (or merge) to `master`, the action will:
   * Get latest tag
   * Bump tag with minor version unless any commit message contains `#major` or `#patch`
   * Pushes tag to github

--- a/README.md
+++ b/README.md
@@ -32,15 +32,17 @@ jobs:
 
 #### Options
 
-* **REPO_OWNER** ***(required)*** - Required so the action knows which repo to tag.
-* **GITHUB_TOKEN** ***(required)*** - Required for permission permissions.
-* **DEFAULT_BUMP** *(optional)* - (default: `minor`) Which type of SemVar bump to use if none provided.
+* **GITHUB_TOKEN** ***(required)*** - Required for permission to tag the repo.
+* **REPO_OWNER** ***(required)*** - Required to target the repo to tag.
+* **DEFAULT_BUMP** *(optional)* - Which type of bump to use when none explicitly provided (default: `minor`).
 
 *NOTE:* This creates a [lightweight tag](https://developer.github.com/v3/git/refs/#create-a-reference)
 
 ### Bumping
 
 Any commit message with `#major`, `#minor`, or `#patch` will trigger the respective version bump. If two or more are present, the biggest one will take preference.
+
+This **will not** attempt to tag a commit that has already has a tag.
 
 ### Workflow
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # github-tag-action
 
-A Github Action to automatically bump and tag master, on merge, with the latest semver formatted version.
+A Github Action to automatically bump and tag master, on merge, with the latest SemVer formatted version.
 
 [![Build Status](https://github.com/anothrNick/github-tag-action/workflows/Bump%20version/badge.svg)](https://github.com/anothrNick/github-tag-action/workflows/Bump%20version/badge.svg)
 [![Stable Version](https://img.shields.io/github/v/tag/anothrNick/github-tag-action)](https://img.shields.io/github/v/tag/anothrNick/github-tag-action)
@@ -30,13 +30,17 @@ jobs:
         REPO_OWNER: anothrNick
 ```
 
-Be sure to set the *REPO_OWNER* environment variable so that the action tags your repo.
+#### Options
+
+* **REPO_OWNER** ***(required)*** - Required so the action knows which repo to tag.
+* **GITHUB_TOKEN** ***(required)*** - Required for permission permissions.
+* **DEFAULT_BUMP** *(optional)* - (default: `minor`) Which type of SemVar bump to use if none provided.
 
 *NOTE:* This creates a [lightweight tag](https://developer.github.com/v3/git/refs/#create-a-reference)
 
 ### Bumping
 
-Any commit message with `#major`, `#minor`, or `patch` will trigger the respective version bump.
+Any commit message with `#major`, `#minor`, or `#patch` will trigger the respective version bump. If two or more are present, the biggest one will take preference.
 
 ### Workflow
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ default_semvar_bump=${DEFAULT_BUMP:-minor}
 
 # get latest tag
 tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-tag_commit=commit=$(git rev-list -n 1 $tagag)
+tag_commit=$(git rev-list -n 1 $tag)
 
 # get current commit hash for tag
 commit=$(git rev-parse HEAD)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,26 +1,36 @@
 #!/bin/bash
 
+# config
+default_semvar_bump=${DEFAULT_BUMP:-minor}
+
 # get latest tag
-t=$(git describe --tags `git rev-list --tags --max-count=1`)
+tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+tag_commit=commit=$(git rev-list -n 1 $tagag)
 
 # get current commit hash for tag
 commit=$(git rev-parse HEAD)
 
+if [ "$tag_commit" == "$commit" ]; then
+    echo "No new commits since previous tag. Skipping..."
+    exit 0
+fi
+
 # if there are none, start tags at 0.0.0
-if [ -z "$t" ]
+if [ -z "$tag" ]
 then
     log=$(git log --pretty=oneline)
-    t=0.0.0
+    tag=0.0.0
 else
-    log=$(git log $t..HEAD --pretty=oneline)
+    log=$(git log $tag..HEAD --pretty=oneline)
 fi
 
 # get commit logs and determine home to bump the version
 # supports #major, #minor, #patch (anything else will be 'minor')
 case "$log" in
-    *#major* ) new=$(semver bump major $t);;
-    *#patch* ) new=$(semver bump patch $t);;
-    * ) new=$(semver bump minor $t);;
+    *#major* ) new=$(semver bump major $tag);;
+    *#minor* ) new=$(semver bump minor $tag);;
+    *#patch* ) new=$(semver bump patch $tag);;
+    * ) new=$(semver bump `$default_semvar_bump` $tag);;
 esac
 
 echo $new

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ case "$log" in
     *#major* ) new=$(semver bump major $tag);;
     *#minor* ) new=$(semver bump minor $tag);;
     *#patch* ) new=$(semver bump patch $tag);;
-    * ) new=$(semver bump `$default_semvar_bump` $tag);;
+    * ) new=$(semver bump `echo $default_semvar_bump` $tag);;
 esac
 
 echo $new


### PR DESCRIPTION
* Skips if commit is already tagged (https://github.com/anothrNick/github-tag-action/issues/11)
* Adds customisable `DEFAULT_BUMP` config, defaults to `minor`.