### PR TITLE
Create action.yml metadata. Set new tag to output for other builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
 FROM alpine
-LABEL "com.github.actions.name"="Github Tag Bump"
-LABEL "com.github.actions.description"="Bump and push git tag on merge"
-LABEL "com.github.actions.icon"="git-merge"
-LABEL "com.github.actions.color"="purple"
-
 LABEL "repository"="https://github.com/anothrNick/github-tag-action"
 LABEL "homepage"="https://github.com/anothrNick/github-tag-action"
 LABEL "maintainer"="Nick Sjostrom"

--- a/README.md
+++ b/README.md
@@ -31,9 +31,15 @@ jobs:
 
 #### Options
 
+**Environment Variables**
+
 * **GITHUB_TOKEN** ***(required)*** - Required for permission to tag the repo.
 * **DEFAULT_BUMP** *(optional)* - Which type of bump to use when none explicitly provided (default: `minor`).
 * **WITH_V** *(optional)* - Tag version with `v` character.
+
+#### Outputs
+
+* **new_tag** - The value of the newly created tag.
 
 > ***Note:*** This action creates a [lightweight tag](https://developer.github.com/v3/git/refs/#create-a-reference).
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,12 @@
+name: 'Github Tag Bump'
+description: 'Bump and push git tag on merge'
+author: 'Nick Sjostrom'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+outputs:
+  new_tag:
+    description: 'Generated tag'
+branding:
+  icon: 'git-merge'  
+  color: 'purple'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,7 @@ case "$log" in
     * ) new=$(semver bump `echo $default_semvar_bump` $tag);;
 esac
 
+# prefix with 'v'
 if $with_v
 then
     new="v$new"
@@ -41,6 +42,10 @@ fi
 
 echo $new
 
+# set output
+echo ::set-output name=new_tag::$new
+
+# push new tag ref to github
 dt=$(date '+%Y-%m-%dT%H:%M:%SZ')
 full_name=$GITHUB_REPOSITORY
 git_refs_url=$(jq .repository.git_refs_url $GITHUB_EVENT_PATH | tr -d '"' | sed 's/{\/sha}//g')


### PR DESCRIPTION
Implements #16 

Creates the newly required metadata file at the root of the action directory, per https://help.github.com/en/articles/metadata-syntax-for-github-actions and https://github.blog/changelog/2019-10-10-the-github-actions-marketplace-now-requires-an-actions-metadata-file/

This defines a new output parameter (https://help.github.com/en/articles/metadata-syntax-for-github-actions#outputs) as `new_tag` that subsequent actions can use later in the workflow.