### PR TITLE
Pre-release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ jobs:
 * **GITHUB_TOKEN** ***(required)*** - Required for permission to tag the repo.
 * **DEFAULT_BUMP** *(optional)* - Which type of bump to use when none explicitly provided (default: `minor`).
 * **WITH_V** *(optional)* - Tag version with `v` character.
+* **PRE_RELEASE** *(optional)* - Postfixes the version with the commit hash and does not tag
 
 #### Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@
 # config
 default_semvar_bump=${DEFAULT_BUMP:-minor}
 with_v=${WITH_V:-false}
+pre_release=${PRE_RELEASE:-false}
 
 # get latest tag
 tag=$(git describe --tags `git rev-list --tags --max-count=1`)
@@ -40,10 +41,20 @@ then
     new="v$new"
 fi
 
+if $pre_release
+then
+    new="$new-${commit:0:7}"
+fi
+
 echo $new
 
 # set output
 echo ::set-output name=new_tag::$new
+
+if $pre_release
+then
+    exit 0
+fi
 
 # push new tag ref to github
 dt=$(date '+%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
Fixes #18 

The goal of this PR is to avoid confusion when a Pull Request or a feature branch computes a version number. This lets the user define that only the master branch should be tagged.

Other branches or pull requests will compute a new version number (bumped as usual). But the version will be marked as a pre-release thanks to the -prerelease postfix.
So, instead of computing `1.2.3`, the script will compute `1.2.3-1a2b3c4d5e`.
And the next revision of the Pull Request (or feature branch build) will compute a similar version `1.2.3-2b3c4d5e6f` (since no tag was put and supposedly master did not evolve in the meantime).

This Pull Request is just to start the discussion, I know that expectations are very different based on your workflow.