### PR TITLE
Pre-release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ jobs:
 * **GITHUB_TOKEN** ***(required)*** - Required for permission to tag the repo.
 * **DEFAULT_BUMP** *(optional)* - Which type of bump to use when none explicitly provided (default: `minor`).
 * **WITH_V** *(optional)* - Tag version with `v` character.
+* **RELEASE_BRANCHES** *(optional)* - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
 
 #### Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,18 @@
 # config
 default_semvar_bump=${DEFAULT_BUMP:-minor}
 with_v=${WITH_V:-false}
+release_branches=${RELEASE_BRANCHES:-master}
+
+pre_release="true"
+IFS=',' read -ra branch <<< "$release_branches"
+for b in "${branch[@]}"; do
+    echo "Is $b a match for ${GITHUB_REF#'refs/heads/'}"
+    if [[ "${GITHUB_REF#'refs/heads/'}" =~ $b ]]
+    then
+        pre_release="false"
+    fi
+done
+echo "pre_release = $pre_release"
 
 # get latest tag
 tag=$(git describe --tags `git rev-list --tags --max-count=1`)
@@ -40,10 +52,21 @@ then
     new="v$new"
 fi
 
+if $pre_release
+then
+    new="$new-${commit:0:7}"
+fi
+
 echo $new
 
 # set output
 echo ::set-output name=new_tag::$new
+
+if $pre_release
+then
+    echo "This branch is not a release branch. Skipping the tag creation."
+    exit 0
+fi
 
 # push new tag ref to github
 dt=$(date '+%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
Fixes #18

The goal of this PR is to avoid confusion when a Pull Request or a feature branch computes a version number. This lets the user define that only the master branch should be tagged.

Other branches or pull requests will compute a new version number (bumped as usual). But the version will be marked as a pre-release thanks to the prerelease postfix.
So, instead of computing 1.2.3, the script will compute 1.2.3-1a2b3c4.
And the next revision of the Pull Request (or feature branch build) will compute a similar version 1.2.3-2b3c4d5 (since no tag was put and supposedly master did not evolve in the meantime).

Example of configuration:
```
      env:
        RELEASE_BRANCHES: "master,release/*"
```

or
```
      env:
        RELEASE_BRANCHES: "production"
```
or (which is the default behavior)
```
      env:
        RELEASE_BRANCH: "master"
```
In the future, I could help introduce a mechanism where we bump the _latest tag_ of the **current (or destination) branch**. It is a bit more complex but certainly worth it in terms of flexibility.
This way , you can have all kind of branches that evolve independently. For example:
* `master`: `3.4.5`, `3.6.0` ...
* `release/1` : `1.0.3`, `1.1.0`...
* `release/2.1` : `2.1.3`, `2.1.4`...
* `release/2.2` : `2.2.0`, `2.2.1`...

This requires looking for the latest tag of _that_ branch.
But let's keep that for later!