### PR TITLE
Added new 'Custom_tag' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ jobs:
 * **DEFAULT_BUMP** *(optional)* - Which type of bump to use when none explicitly provided (default: `minor`).
 * **WITH_V** *(optional)* - Tag version with `v` character.
 * **RELEASE_BRANCHES** *(optional)* - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
+* **CUSTOM_TAG** *(optional)* - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
 
 #### Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@
 default_semvar_bump=${DEFAULT_BUMP:-minor}
 with_v=${WITH_V:-false}
 release_branches=${RELEASE_BRANCHES:-master}
+custom_tag=${CUSTOM_TAG}
 
 pre_release="true"
 IFS=',' read -ra branch <<< "$release_branches"
@@ -55,6 +56,11 @@ fi
 if $pre_release
 then
     new="$new-${commit:0:7}"
+fi
+
+if [ ! -z $custom_tag ]
+then
+    new="$custom_tag"
 fi
 
 echo $new


### PR DESCRIPTION
This will allow the tag to be set directly from the action script.
Useful when tagging docker images based on the version of the base images they are based on.
