### PR TITLE
Adding DRY_RUN feature that fixes #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ _NOTE: set the fetch-depth for `actions/checkout@master` to be sure you retrieve
 * **RELEASE_BRANCHES** *(optional)* - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
 * **CUSTOM_TAG** *(optional)* - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
 * **SOURCE** *(optional)* - Operate on a relative path under $GITHUB_WORKSPACE.
+* **DRY_RUN** *(optional)* - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are ```true``` and ```false``` (default). 
 
 #### Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ with_v=${WITH_V:-false}
 release_branches=${RELEASE_BRANCHES:-master}
 custom_tag=${CUSTOM_TAG}
 source=${SOURCE:-.}
+dryrun=${DRY_RUN:-false}
 
 cd ${GITHUB_WORKSPACE}/${source}
 
@@ -80,7 +81,15 @@ echo $new
 
 # set outputs
 echo ::set-output name=new_tag::$new
+
+if $dryrun
+then
+    echo ::set-output name=tag::$tag
+    exit 0
+fi 
+
 echo ::set-output name=tag::$new
+
 
 if $pre_release
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,6 +82,7 @@ echo $new
 # set outputs
 echo ::set-output name=new_tag::$new
 
+# use dry run to determine the next tag
 if $dryrun
 then
     echo ::set-output name=tag::$tag


### PR DESCRIPTION
This PR add the dry_run feature to allow more complex version bumping processes. While this is not necessarily needed for NPM, it makes a lot of sense with other packaging tools or when more complex sets should be done for finalising a tag-release.

I tested this with [phish108/node-foobar](/phish108/node-foobar) without problems. 

The actions are setup as follows: 

```yml
# ...
jobs:
  # ...
  release: 
    needs: build
    runs-on: [ubuntu-latest]
    strategy:
      matrix:
        node-version: 
        - 12
    steps:
      - uses: actions/checkout@v2
      - name: Use Node.js ${{ matrix.node-version }}
        uses: actions/setup-node@v1
        with:
          node-version: ${{ matrix.node-version }}
      # - run: npm ci
      - run: |
          git config --local user.email "action@github.com"
          git config --local user.name "GitHub Action"
      - uses: phish108/github-tag-action@p1.17.4
        id: tagger
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          DRY_RUN: true
      - run: echo ${{ steps.tagger.outputs.tag }} ${{ steps.tagger.outputs.new_tag }}
      - run: npm --no-git-tag-version --allow-same-version version ${{ steps.tagger.outputs.new_tag }}
      - run: git commit -m "version bump to $NPM_VERSION" -a
        env: 
          NPM_VERSION: ${{ steps.tagger.outputs.new_tag }}
      - name: Push changes
        uses: ad-m/github-push-action@master
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
      - uses: phish108/github-tag-action@p1.17.4
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          WITH_V: true
```

Note, that I used my fork for testing, where I added preliminary tag. 