### PR TITLE
use the checkedout branch for release checking

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,11 +10,13 @@ dryrun=${DRY_RUN:-false}
 
 cd ${GITHUB_WORKSPACE}/${source}
 
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
 pre_release="true"
 IFS=',' read -ra branch <<< "$release_branches"
 for b in "${branch[@]}"; do
-    echo "Is $b a match for ${GITHUB_REF#'refs/heads/'}"
-    if [[ "${GITHUB_REF#'refs/heads/'}" =~ $b ]]
+    echo "Is $b a match for ${current_branch}"
+    if [[ "${current_branch}" =~ $b ]]
     then
         pre_release="false"
     fi


### PR DESCRIPTION
As pointed out in #49 GITHUB_REF can be misleading. Because it is impossible to overwrite this environment variable, I suggest to be failsafe and use the actual checkout branch instead the branch that triggered the workflow. 