### PR TITLE
Allow bump message in body of commit message

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ fi
 # if there are none, start tags at 0.0.0
 if [ -z "$tag" ]
 then
-    log=$(git log --pretty=oneline)
+    log=$(git log --pretty='%B')
     tag=0.0.0
 else
     log=$(git log $tag..HEAD --pretty=oneline)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ then
     log=$(git log --pretty='%B')
     tag=0.0.0
 else
-    log=$(git log $tag..HEAD --pretty=oneline)
+    log=$(git log $tag..HEAD --pretty='%B')
 fi
 
 echo $log


### PR DESCRIPTION
Fixes https://github.com/anothrNick/github-tag-action/issues/53.

This PR changes the log format from `oneline` to [`%B`](https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-B), which prints the raw body (unwrapped subject and body).