### PR TITLE
Adding support for DEFAULT_BUMP=none

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ _NOTE: set the fetch-depth for `actions/checkout@master` to be sure you retrieve
 
 **Manual Bumping:** Any commit message that includes `#major`, `#minor`, or `#patch` will trigger the respective version bump. If two or more are present, the highest-ranking one will take precedence.
 
-**Automatic Bumping:** If no `#major`, `#minor` or `#patch` tag is contained in the commit messages, it will bump whichever `DEFAULT_BUMP` is set to (which is `minor` by default).
+**Automatic Bumping:** If no `#major`, `#minor` or `#patch` tag is contained in the commit messages, it will bump whichever `DEFAULT_BUMP` is set to (which is `minor` by default). Disable this by setting `DEFAULT_BUMP` to `none`.
 
 > ***Note:*** This action **will not** bump the tag if the `HEAD` commit has already been tagged.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,13 +48,23 @@ fi
 
 echo $log
 
+# this will bump the semvar using the default bump level,
+# or it will simply pass if the default was "none"
+function default-bump {
+  if [ "$default_semvar_bump" == "none" ]; then
+    return
+  else
+    semver bump "${default_semvar_bump}" $tag
+  fi
+}
+
 # get commit logs and determine home to bump the version
 # supports #major, #minor, #patch (anything else will be 'minor')
 case "$log" in
     *#major* ) new=$(semver bump major $tag);;
     *#minor* ) new=$(semver bump minor $tag);;
     *#patch* ) new=$(semver bump patch $tag);;
-    * ) new=$(semver bump `echo $default_semvar_bump` $tag);;
+    * ) new=$(default-bump);;
 esac
 
 # did we get a new tag?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,6 +52,7 @@ echo $log
 # or it will simply pass if the default was "none"
 function default-bump {
   if [ "$default_semvar_bump" == "none" ]; then
+    echo "Default bump was set to none. Skipping..."
     return
   else
     semver bump "${default_semvar_bump}" $tag

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ echo $log
 function default-bump {
   if [ "$default_semvar_bump" == "none" ]; then
     echo "Default bump was set to none. Skipping..."
-    return
+    exit 0
   else
     semver bump "${default_semvar_bump}" $tag
   fi


### PR DESCRIPTION
This addresses https://github.com/anothrNick/github-tag-action/issues/56

By setting `DEFAULT_BUMP=none`, automatic bumping will be disabled. You must provide `#major`/`#minor`/`#patch` to your git commits to trigger the version bump.