### PR TITLE
[#51] Added ability to bump tags from the checked out branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ _NOTE: set the fetch-depth for `actions/checkout@master` to be sure you retrieve
 * **RELEASE_BRANCHES** *(optional)* - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
 * **CUSTOM_TAG** *(optional)* - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
 * **SOURCE** *(optional)* - Operate on a relative path under $GITHUB_WORKSPACE.
-* **DRY_RUN** *(optional)* - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are ```true``` and ```false``` (default). 
+* **DRY_RUN** *(optional)* - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are ```true``` and ```false``` (default).
 * **INITIAL_VERSION** *(optional)* - Set initial version before bump. Default `0.0.0`.
-* **TAG_CONTEXT** *(optional)* - Set the comtext of the previous tag. Possible values are `repo` (default) or `branch`.
+* **TAG_CONTEXT** *(optional)* - Set the context of the previous tag. Possible values are `repo` (default) or `branch`.
 
 #### Outputs
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ _NOTE: set the fetch-depth for `actions/checkout@master` to be sure you retrieve
 * **SOURCE** *(optional)* - Operate on a relative path under $GITHUB_WORKSPACE.
 * **DRY_RUN** *(optional)* - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are ```true``` and ```false``` (default). 
 * **INITIAL_VERSION** *(optional)* - Set initial version before bump. Default `0.0.0`.
+* **TAG_CONTEXT** *(optional)* - Set the comtext of the previous tag. Possible values are `repo` (default) or `branch`.
 
 #### Outputs
 


### PR DESCRIPTION
resolves anothrNick/github-tag-action#51

To enable the desired behavior of the ticket, whilst not altering existing behavior I added a `TAG_CONTEXT` env var that swaps out the functionality of the `git for-each-ref` and subs in the `git describe`. The filtering behavior of the original is carried to the `describe` functionality. 

```yaml
env:
  - TAG_CONTEXT=branch
```

Will exit with a non-zero code if a unrecognised `TAG_CONTEXT` is provided.