### PR TITLE
Create local git tag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -122,6 +122,9 @@ then
     exit 0
 fi
 
+# create local git tag
+git tag $new
+
 # push new tag ref to github
 dt=$(date '+%Y-%m-%dT%H:%M:%SZ')
 full_name=$GITHUB_REPOSITORY


### PR DESCRIPTION
## What

Create the newly new git tag locally (not only remotely).

## Why

This would prevent hacking like: https://github.com/golang-templates/seed/blob/master/.github/workflows/build.yml#L35
I imagine they may be more use cases where it would be helpful.
Basically I have done it this way, because of the issue described here: https://github.com/anothrNick/github-tag-action/issues/64
I do not want to create a dedicated Personal GitHub Token. I want to create a repository template that anyone can use with minimal interaction.