### PR TITLE
Fix issue with DEFAULT_BUMP: none

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,6 +82,11 @@ esac
 
 echo $part
 
+if [ "$new" == "Default bump was set to none. Skipping..." ]; then
+    echo "$new"
+    exit 0
+fi
+
 # did we get a new tag?
 if [ ! -z "$new" ]
 then


### PR DESCRIPTION
Need to exit the script not just the function, otherwise $new is set to the string "Default bump was set to none. Skipping..." and pushed, resulting in an error.

Fixes #77 