### PR TITLE
Fix: Exiting when default bump set to none

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,24 +60,19 @@ fi
 
 echo $log
 
-# this will bump the semvar using the default bump level,
-# or it will simply pass if the default was "none"
-function default-bump {
-  if [ "$default_semvar_bump" == "none" ]; then
-    echo "Default bump was set to none. Skipping..."
-    exit 0
-  else
-    semver bump "${default_semvar_bump}" $tag
-  fi
-}
-
 # get commit logs and determine home to bump the version
 # supports #major, #minor, #patch (anything else will be 'minor')
 case "$log" in
     *#major* ) new=$(semver bump major $tag); part="major";;
     *#minor* ) new=$(semver bump minor $tag); part="minor";;
     *#patch* ) new=$(semver bump patch $tag); part="patch";;
-    * ) new=$(default-bump); part=$default_semvar_bump;;
+    * ) 
+        if [ "$default_semvar_bump" == "none" ]; then
+            echo "Default bump was set to none. Skipping..."; exit 0 
+        else 
+            new=$(semver bump "${default_semvar_bump}" $tag); part=$default_semvar_bump 
+        fi 
+        ;;
 esac
 
 echo $part


### PR DESCRIPTION
Previously, the action would fail if `DEFAULT_BUMP` was set to `none`. This fixes the issue in a cleaner way than this other pull-request #78 