### PR TITLE
#minor This adds an optional "verbose" tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all
 * **INITIAL_VERSION** *(optional)* - Set initial version before bump. Default `0.0.0`.
 * **TAG_CONTEXT** *(optional)* - Set the context of the previous tag. Possible values are `repo` (default) or `branch`.
 * **PRERELEASE_SUFFIX** *(optional)* - Suffix for your prerelease versions, `beta` by default. Note this will only be used if a prerelease branch.
+* **VERBOSE** *(optional)* - Print git logs. For some projects these logs may be very large. Possible values are ```true``` (default) and ```false```. 
 
 #### Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ dryrun=${DRY_RUN:-false}
 initial_version=${INITIAL_VERSION:-0.0.0}
 tag_context=${TAG_CONTEXT:-repo}
 suffix=${PRERELEASE_SUFFIX:-beta}
+verbose=${VERBOSE:-true}
 
 cd ${GITHUB_WORKSPACE}/${source}
 
@@ -25,6 +26,7 @@ echo -e "\tDRY_RUN: ${dryrun}"
 echo -e "\tINITIAL_VERSION: ${initial_version}"
 echo -e "\tTAG_CONTEXT: ${tag_context}"
 echo -e "\tPRERELEASE_SUFFIX: ${suffix}"
+echo -e "\tVERBOSE: ${verbose}"
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
@@ -77,7 +79,11 @@ if [ "$tag_commit" == "$commit" ]; then
     exit 0
 fi
 
-echo $log
+# echo log if verbose is wanted
+if $verbose
+then
+  echo $log
+fi
 
 case "$log" in
     *#major* ) new=$(semver -i major $tag); part="major";;


### PR DESCRIPTION
For larger projects, printing the git logs can be very noisy in action logs, making it difficult to debug, etc. This optional flag is defaulted to 'true' to keep functionality familiar for existing workflows.