### PR TITLE
Added new optional PREFIX parameter to define a tag prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all
 
 * **GITHUB_TOKEN** ***(required)*** - Required for permission to tag the repo.
 * **DEFAULT_BUMP** *(optional)* - Which type of bump to use when none explicitly provided (default: `minor`).
-* **WITH_V** *(optional)* - Tag version with `v` character.
+* **PREFIX** *(optional)* - Adds a prefix before version number.
 * **RELEASE_BRANCHES** *(optional)* - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
 * **CUSTOM_TAG** *(optional)* - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
 * **SOURCE** *(optional)* - Operate on a relative path under $GITHUB_WORKSPACE.
@@ -53,6 +53,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all
 #### Outputs
 
 * **new_tag** - The value of the newly created tag.
+* **new_tag_without_prefix** - The value of the newly created tag without specified prefix.
 * **tag** - The value of the latest tag after running this action.
 * **part** - The part of version which was bumped.
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ runs:
 outputs:
   new_tag:
     description: 'Generated tag'
+  new_tag_without_prefix:
+    description: 'Generated tag without specified prefix'
   tag:
     description: 'The latest tag after running this action'
   part:


### PR DESCRIPTION
Added a possibility to define an optional **PREFIX** parameter to be added before x.y.z version number.
Removed **WITH_V** parameter - omitting **PREFIX** results in the same behaviour as setting **WITH_V** to _false_ in a previous versions.

Closes #72 