### PR TITLE
[release branches] add main as default release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all
   * Get latest tag
   * Bump tag with minor version unless any commit message contains `#major` or `#patch`
   * Pushes tag to github
-  * If triggered on your repo's default branch (`master` if unchanged), the bump version will be a release tag.
+  * If triggered on your repo's default branch (`master` or `main` if unchanged), the bump version will be a release tag.
   * If triggered on any other branch, a prerelease will be generated, depending on the bump, starting with `*-<PRERELEASE_SUFFIX>.1`, `*-<PRERELEASE_SUFFIX>.2`, ...
 
 ### Credits

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 # config
 default_semvar_bump=${DEFAULT_BUMP:-minor}
 with_v=${WITH_V:-false}
-release_branches=${RELEASE_BRANCHES:-master}
+release_branches=${RELEASE_BRANCHES:-master,main}
 custom_tag=${CUSTOM_TAG}
 source=${SOURCE:-.}
 dryrun=${DRY_RUN:-false}


### PR DESCRIPTION
The default release branches are `main` and `master`