### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.10
 LABEL "repository"="https://github.com/anothrNick/github-tag-action"
 LABEL "homepage"="https://github.com/anothrNick/github-tag-action"
 LABEL "maintainer"="Nick Sjostrom"


### PR DESCRIPTION
Latest alpine seems to have a problem resolving the hostname:
```
pre_release = false
fatal: unable to access 'https://github.tools.sap/coresystemsFSM/actions/': Could not resolve host: github.tools.sap
```

Adding a fixed version solves the issue.