### PR TITLE
Only set pre_tag to initial version if no previous was found and it i…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,10 @@ if [ -z "$tag" ]
 then
     log=$(git log --pretty='%B')
     tag="$initial_version"
-    pre_tag="$initial_version"
+    if [ -z "$pre_tag" ] && $pre_release
+    then
+      pre_tag="$initial_version"
+    fi
 else
     log=$(git log $tag..HEAD --pretty='%B')
 fi


### PR DESCRIPTION
Relates to https://github.com/anothrNick/github-tag-action/issues/97

In `entrypoint.sh`, the `tag` and `pre_tag` variables are set via the respective context (repo | branch). 

Current behavior:
For a pre release -> If no `tag` was found, but even if a `pre_tag` was found, the script will keep trying to bump off of `initial_version`, causing a conflict as the generated pre release tag already exists.

Altered behavior:
For a pre relaese -> If no `tag` was found, but a `pre_tag` was found, the script will bump off of `pre_tag`, creating new pre releases as expected.