### PR TITLE
add previous tag to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all
 #### Outputs
 
 - **new_tag** - The value of the newly created tag.
+- **pre_tag** - The value of the previous tag.
 - **tag** - The value of the latest tag after running this action.
 - **part** - The part of version which was bumped.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -132,8 +132,10 @@ fi
 
 if $pre_release
 then
+    echo ::set-output name=pre_tag::${pre_tag}
     echo -e "Bumping tag ${pre_tag}. \n\tNew tag ${new}"
 else
+    echo ::set-output name=pre_tag::${tag}
     echo -e "Bumping tag ${tag}. \n\tNew tag ${new}"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -135,7 +135,7 @@ then
     echo ::set-output name=pre_tag::${pre_tag}
     echo -e "Bumping tag ${pre_tag}. \n\tNew tag ${new}"
 else
-    echo ::set-output name=pre_tag::${tag}
+    echo ::set-output name=tag::${tag}
     echo -e "Bumping tag ${tag}. \n\tNew tag ${new}"
 fi
 


### PR DESCRIPTION
I have found it beneficial to have access to the tag used to generate `new_tag`. This is particularly useful during dry-runs to extract the current tag with the release suffix.