### PR TITLE
Fix  'with_v' tag regex selection

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,7 @@ git fetch --tags
 tagFmt="^[0-9]+\.[0-9]+\.[0-9]+$" 
 preTagFmt="^[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)?$" 
 
-if [ with_v ]
+if $with_v
 then 
     tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
     preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)?$"


### PR DESCRIPTION
This fixes a bug in master that causes the `tagFmt` to always use the `with_v == true` format.

Edit: Note, enabling WITH_V after a more recent non-v tag is still broken, however at least in that case you can manually tag a newer `v` prefixed tag and and continue on.

I tested this in Docker by changing `-e WITH_V=` 
Examples:
### current master (3272e7a58f6c71ee9ede35f53b114e1bb9a91347)
```

# -e WITH_V=true
Bumping tag v2.6.13.
	New tag v2.6.14
::set-output name=new_tag::v2.6.14
::set-output name=part::patch
::set-output name=tag::v2.6.13

# -e WITH_V=false
Bumping tag v2.6.13.
	New tag 2.6.14
::set-output name=new_tag::2.6.14
::set-output name=part::patch
::set-output name=tag::v2.6.13
```

### This PR
```
# -e WITH_V=true
# manually tagging `v2.6.16` would resolve this 
Bumping tag v2.6.13.
	New tag v2.6.14
::set-output name=new_tag::v2.6.14
::set-output name=part::patch
::set-output name=tag::v2.6.13

# -e WITH_V=false
Bumping tag 2.6.15.
	New tag 2.6.16
::set-output name=new_tag::2.6.16
::set-output name=part::patch
::set-output name=tag::2.6.15
```


Tag range used in these tests:
```
v2.6.13
v2.6.12
v2.6.11
2.6.15
2.6.14
2.6.10
2.6.9
2.6.8
2.6.7
2.6.6
2.6.5
2.6.4
2.6.3
2.6.2
2.6.1
2.6.0
2.5.1
2.5.0
```