### PR TITLE
Semver sort

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,7 @@ git fetch --tags
 tagFmt="^[0-9]+\.[0-9]+\.[0-9]+$" 
 preTagFmt="^[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)?$" 
 
-if [ with_v ]
+if $with_v
 then 
     tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
     preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)?$"


### PR DESCRIPTION
This PR replaces https://github.com/anothrNick/github-tag-action/pull/133

This PR address the lingering issue in #133 where `with_v = true` would always use the most recent `v` prefix tag even if it wasn't the actual most recent tag.
For example, `with_v` would update from `v2.6.13` to `v2.6.14` even if the tag `2.6.20` exists.
  
  
The approach taken here is simple:
- pull all tags that match semver with or without the `v` prefix
- use the semver npm script to normalize and sort the list. [semver will automatically strip leading](https://docs.npmjs.com/cli/v6/using-npm/semver#versions) `v` from version tags
- after the version has been bumped, prefix version with `v` if `with_v` is true


