### PR TITLE
fix semver version list input format

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,14 +54,14 @@ case "$tag_context" in
         tag="$(semver $taglist | tail -n 1)"
 
         pre_taglist="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$preTagFmt")"
-        pre_tag="$(semver "$pre_taglist" | tail -n 1)"
+        pre_tag="$(semver $pre_taglist | tail -n 1)"
         ;;
     *branch*) 
         taglist="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$tagFmt")"
         tag="$(semver $taglist | tail -n 1)"
 
         pre_taglist="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$preTagFmt")"
-        pre_tag=$(semver "$pre_taglist" | tail -n 1)
+        pre_tag=$(semver $pre_taglist | tail -n 1)
         ;;
     * ) echo "Unrecognised context"; exit 1;;
 esac

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,17 +50,17 @@ preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)?$"
 # get latest tag that looks like a semver (with or without v)
 case "$tag_context" in
     *repo*) 
-        taglist="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$tagFmt")"
+        taglist="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$tagFmt" | tr '\n' ' ')"
         tag="$(semver $taglist | tail -n 1)"
 
-        pre_taglist="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$preTagFmt")"
+        pre_taglist="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$preTagFmt" | tr '\n' ' ')"
         pre_tag="$(semver $pre_taglist | tail -n 1)"
         ;;
     *branch*) 
-        taglist="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$tagFmt")"
+        taglist="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$tagFmt" | tr '\n' ' ')"
         tag="$(semver $taglist | tail -n 1)"
 
-        pre_taglist="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$preTagFmt")"
+        pre_taglist="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$preTagFmt" | tr '\n' ' ')"
         pre_tag=$(semver $pre_taglist | tail -n 1)
         ;;
     * ) echo "Unrecognised context"; exit 1;;


### PR DESCRIPTION
Related to #134 

The values for `pre_taglist` and `taglist` include newline characters.

```bash
#Ex
$ export taglist="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$tagFmt")"
$ echo -e "$taglist"

1.4.0
1.3.0
1.2.0
1.1.0
```


 `semver` interprets the quoted input as a single argument:
```bash
$ semver "1.1.0\n1.2.0"

# no output

$ semver "1.1.0 1.2.0"

# no output
```


The fix is to replace newline characters with spaces between versions, and provide the input version list arguments unquoted.
