### PR TITLE
fixes for: suffix.X in pre-tags bumps & refarctor some of the shell logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all
 - **DEFAULT_BUMP** _(optional)_ - Which type of bump to use when none explicitly provided (default: `minor`).
 - **WITH_V** _(optional)_ - Tag version with `v` character.
 - **RELEASE_BRANCHES** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
-**CUSTOM_TAG** _(optional)_ - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
+- **CUSTOM_TAG** _(optional)_ - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
 - **SOURCE** _(optional)_ - Operate on a relative path under $GITHUB_WORKSPACE.
 - **DRY_RUN** _(optional)_ - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are `true` and `false` (default).
 - **INITIAL_VERSION** _(optional)_ - Set initial version before bump. Default `0.0.0`.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all
 - **DEFAULT_BUMP** _(optional)_ - Which type of bump to use when none explicitly provided (default: `minor`).
 - **WITH_V** _(optional)_ - Tag version with `v` character.
 - **RELEASE_BRANCHES** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
+**CUSTOM_TAG** _(optional)_ - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
 - **SOURCE** _(optional)_ - Operate on a relative path under $GITHUB_WORKSPACE.
 - **DRY_RUN** _(optional)_ - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are `true` and `false` (default).
 - **INITIAL_VERSION** _(optional)_ - Set initial version before bump. Default `0.0.0`.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all
 - **DEFAULT_BUMP** _(optional)_ - Which type of bump to use when none explicitly provided (default: `minor`).
 - **WITH_V** _(optional)_ - Tag version with `v` character.
 - **RELEASE_BRANCHES** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
-- **CUSTOM_TAG** _(optional)_ - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
 - **SOURCE** _(optional)_ - Operate on a relative path under $GITHUB_WORKSPACE.
 - **DRY_RUN** _(optional)_ - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are `true` and `false` (default).
 - **INITIAL_VERSION** _(optional)_ - Set initial version before bump. Default `0.0.0`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,9 +44,9 @@ echo "pre_release = $pre_release"
 
 # fetch tags
 git fetch --tags
-    
-tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
-preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
+
+tagFmt="^v$[0-9]+\.[0-9]+\.[0-9]+$"
+preTagFmt="^v[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
 
 # get latest tag that looks like a semver (with or without v)
 case "$tag_context" in
@@ -61,7 +61,6 @@ case "$tag_context" in
     * ) echo "Unrecognised context"
         exit 1;;
 esac
-
 
 # if there are none, start tags at INITIAL_VERSION which defaults to 0.0.0
 if [ -z "$tag" ]
@@ -83,12 +82,7 @@ then
         fi
     fi
 else
-    if $with_v
-    then
-        log=$(git log v${tag}..HEAD --pretty='%B' --)
-    else
-        log=$(git log ${tag}..HEAD --pretty='%B' --)
-    fi
+    log=$(git log ${tag}..HEAD --pretty='%B' --)
 fi
 
 # get current commit hash for tag

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -136,7 +136,7 @@ then
         then
             new="v$(semver -i prerelease ${pre_tag} --preid ${suffix})"
         else
-            new=$(semver -i prerelease ${pre_tag} --preid ${suffix})
+            new="$(semver -i prerelease ${pre_tag} --preid ${suffix})"
         fi
         echo -e "Bumping ${suffix} pre-tag ${pre_tag}. New pre-tag ${new}"
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -136,7 +136,7 @@ esac
 if $pre_release
 then
     # Already a prerelease available, bump it
-    if [ "$pre_tag" =~ "$new" ]] && [ "$pre_tag" =~ "$suffix" ]]
+    if [[ "$pre_tag" =~ "$new" ]] && [[ "$pre_tag" =~ "$suffix" ]]
     then
         if $with_v
         then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -146,7 +146,7 @@ then
         else
             new="$new-$suffix.0"
         fi
-        echo -e "Setting ${suffix} pre-tag  ${pre_tag}. With pre-tag ${new}"
+        echo -e "Setting ${suffix} pre-tag ${pre_tag}. With pre-tag ${new}"
     fi
     part="pre-$part"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,8 +36,8 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 pre_release="true"
 IFS=',' read -ra branch <<< "$release_branches"
 for b in "${branch[@]}"; do
-    echo "Is $b a match for ${current_branch}"
-    if [[ "${current_branch}" =~ $b ]]
+    # check if ${current_branch} is in ${release_branches}
+    if [[ "$current_branch" == "$b" ]]
     then
         pre_release="false"
     fi
@@ -73,14 +73,14 @@ esac
 # if there are none, start tags at INITIAL_VERSION which defaults to 0.0.0
 if [ -z "$tag" ]
 then
-    log=$(git log --pretty='%B')
+    log=$(git log --pretty='%B' --)
     tag="$initial_version"
     if [ -z "$pre_tag" ] && $pre_release
     then
       pre_tag="$initial_version"
     fi
 else
-    log=$(git log $tag..HEAD --pretty='%B')
+    log=$(git log ${tag}..HEAD --pretty='%B' --)
 fi
 
 # get current commit hash for tag

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -136,7 +136,7 @@ esac
 if $pre_release
 then
     # Already a prerelease available, bump it
-    if [ "$pre_tag" = "$new" ]
+    if [ "$pre_tag" =~ "$new" ]] && [ "$pre_tag" =~ "$suffix" ]]
     then
         if $with_v
         then
@@ -144,7 +144,7 @@ then
         else
             new=$(semver -i prerelease ${pre_tag} --preid ${suffix})
         fi
-        part="pre-$part"
+        echo -e "Bumping ${suffix} pre-tag ${pre_tag}. \n\tNew pre-tag ${new}"
     else
         if $with_v
         then
@@ -152,9 +152,9 @@ then
         else
             new="$new-$suffix.0"
         fi
-        part="pre-$part"
+        echo -e "Setting ${suffix} pre-tag  ${pre_tag}. \n\With pre-tag ${new}"
     fi
-    echo -e "Bumping tag ${pre_tag}. \n\tNew tag ${new}"
+    part="pre-$part"
 else
     echo -e "Bumping tag ${tag}. \n\tNew tag ${new}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -157,6 +157,10 @@ then
     part="pre-$part"
 else
     echo -e "Bumping tag ${tag}. New tag ${new}"
+    if $with_v
+    then
+        new="v$new"
+    fi
 fi
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ set -o pipefail
 default_semvar_bump=${DEFAULT_BUMP:-minor}
 with_v=${WITH_V:-false}
 release_branches=${RELEASE_BRANCHES:-master,main}
+custom_tag=${CUSTOM_TAG}
 source=${SOURCE:-.}
 dryrun=${DRY_RUN:-false}
 initial_version=${INITIAL_VERSION:-0.0.0}
@@ -22,6 +23,7 @@ echo "*** CONFIGURATION ***"
 echo -e "\tDEFAULT_BUMP: ${default_semvar_bump}"
 echo -e "\tWITH_V: ${with_v}"
 echo -e "\tRELEASE_BRANCHES: ${release_branches}"
+echo -e "\tCUSTOM_TAG: ${custom_tag}"
 echo -e "\tSOURCE: ${source}"
 echo -e "\tDRY_RUN: ${dryrun}"
 echo -e "\tINITIAL_VERSION: ${initial_version}"
@@ -157,6 +159,11 @@ else
     fi
 fi
 
+# as defined in readme if CUSTOM_TAG is used any semver calculations are irrelevant.
+if ! [ -z "$custom_tag" ]
+then
+    new="$custom_tag"
+fi
 
 # set outputs
 echo ::set-output name=new_tag::$new

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,8 +45,8 @@ echo "pre_release = $pre_release"
 # fetch tags
 git fetch --tags
 
-tagFmt="^v$[0-9]+\.[0-9]+\.[0-9]+$"
-preTagFmt="^v[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
+tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
+preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
 
 # get latest tag that looks like a semver (with or without v)
 case "$tag_context" in

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -144,7 +144,7 @@ then
         else
             new=$(semver -i prerelease ${pre_tag} --preid ${suffix})
         fi
-        echo -e "Bumping ${suffix} pre-tag ${pre_tag}. \n\tNew pre-tag ${new}"
+        echo -e "Bumping ${suffix} pre-tag ${pre_tag}. New pre-tag ${new}"
     else
         if $with_v
         then
@@ -152,11 +152,11 @@ then
         else
             new="$new-$suffix.0"
         fi
-        echo -e "Setting ${suffix} pre-tag  ${pre_tag}. \n\With pre-tag ${new}"
+        echo -e "Setting ${suffix} pre-tag  ${pre_tag}. With pre-tag ${new}"
     fi
     part="pre-$part"
 else
-    echo -e "Bumping tag ${tag}. \n\tNew tag ${new}"
+    echo -e "Bumping tag ${tag}. New tag ${new}"
 fi
 
 


### PR DESCRIPTION
- too much variable reuse
- now u can bump vX.X.X-suff.X properly ie, v0.0.1-dev.0 bumps to v0.0.1-dev.1 for example for branch work rc release etc
- don't trust semver to tail, prefer head
- changed rexeg slightly to ignore `latest` non semver tags
- sorted pre-release mismatch when ur branch name contains master or main to behave correctly as pre-release anyway
- other small bits here and there

feel free to test from my fork: `sbe-arg/github-tag-action@1.39.6`