### PR TITLE
fix: create tag if there are no existing tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ LABEL "repository"="https://github.com/anothrNick/github-tag-action"
 LABEL "homepage"="https://github.com/anothrNick/github-tag-action"
 LABEL "maintainer"="Nick Sjostrom"
 
-COPY entrypoint.sh /entrypoint.sh
-
 RUN apk update && apk add bash git curl jq && npm install -g semver
+
+COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,18 +50,26 @@ git fetch --tags
 tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$" 
 preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)?$" 
 
+tag=""
+
 # get latest tag that looks like a semver (with or without v)
 case "$tag_context" in
     *repo*) 
         taglist="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$tagFmt")"
-        tag="$(semver $taglist | tail -n 1)"
+        if [ ! -z "$taglist" ]
+        then
+            tag="$(semver $taglist | tail -n 1)"
+        fi
 
         pre_taglist="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$preTagFmt")"
         pre_tag="$(semver "$pre_taglist" | tail -n 1)"
         ;;
     *branch*) 
         taglist="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$tagFmt")"
-        tag="$(semver $taglist | tail -n 1)"
+        if [ ! -z "$taglist" ]
+        then
+            tag="$(semver $taglist | tail -n 1)"
+        fi
 
         pre_taglist="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$preTagFmt")"
         pre_tag=$(semver "$pre_taglist" | tail -n 1)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,33 +55,12 @@ tag=""
 # get latest tag that looks like a semver (with or without v)
 case "$tag_context" in
     *repo*) 
-<<<<<<< HEAD
-        taglist="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$tagFmt")"
-        if [ ! -z "$taglist" ]
-        then
-            tag="$(semver $taglist | tail -n 1)"
-        fi
-
-        pre_taglist="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$preTagFmt")"
-        pre_tag="$(semver "$pre_taglist" | tail -n 1)"
-        ;;
-    *branch*) 
-        taglist="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$tagFmt")"
-        if [ ! -z "$taglist" ]
-        then
-            tag="$(semver $taglist | tail -n 1)"
-        fi
-
-        pre_taglist="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$preTagFmt")"
-        pre_tag=$(semver "$pre_taglist" | tail -n 1)
-=======
         tag="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$tagFmt" | head -n 1)"
         pre_tag="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$preTagFmt" | head -n 1)"
         ;;
     *branch*) 
         tag="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$tagFmt" | head -n 1)"
         pre_tag="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$preTagFmt" | head -n 1)"
->>>>>>> 38e273cbdda80759cc0232a36f559999f4e47d29
         ;;
     * ) echo "Unrecognised context"
         exit 1;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,8 +50,6 @@ git fetch --tags
 tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
 preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
 
-tag=""
-
 # get latest tag that looks like a semver (with or without v)
 case "$tag_context" in
     *repo*) 


### PR DESCRIPTION
### Changes:
- fixes tag if there are no existing tags
- closes https://github.com/anothrNick/github-tag-action/issues/166
- also moves the copy command in the docker image to after the install commands, so you can take advantage of docker layer caching when building the image locally

before the change, the tag variable was set to the last line of the semver help message ("multiple versions to the utility will just sort them.")

### Testing:
Comments out lines in `entrypoint.sh` after line 157 (after the `# set outputs` line) and all `echo ::set-output` lines
builds docker image
runs docker image with entrypoint as bash

Runs these lines to test
```bash
export GITHUB_WORKSPACE=/workspace

mkdir -p ${GITHUB_WORKSPACE} && cd ${GITHUB_WORKSPACE} && git init && git config --global user.name "Jane Doe" && git config --global user.email "jane.doe@email.com" && echo "readme" > readme.txt && git add readme.txt && git commit -m "message"

cd /
./entrypoint.sh
```
Last lines should output:
```bash
Bumping tag 0.0.0. 
	New tag 0.1.0
```
Previously outputed:
```bash
Bumping tag multiple versions to the utility will just sort them.. 
	New tag 
```