### PR TITLE
add v to latest tag if nessecary

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,11 +75,19 @@ if [ -z "$tag" ]
 then
     log=$(git log --pretty='%B')
     tag="$initial_version"
+    if $with_v
+    then
+    	tag="v$tag"
+    fi
     if [ -z "$pre_tag" ] && $pre_release
     then
       pre_tag="$initial_version"
     fi
 else
+    if $with_v
+    then
+    	tag="v$tag"
+    fi
     log=$(git log $tag..HEAD --pretty='%B')
 fi
 


### PR DESCRIPTION
the `semver` command strips the leading v from tags to turn them into proper semantic versions. if you have `with_v` set then the `tag` var needs the v back on it to get the git logs with `git log $tag..HEAD`

this was causing the part arguments to be ignored

if the initial version is set to version with a "v" then this fix would not work for the initial version