### PR TITLE
update docs, node, add docker & bash linting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Summary of changes
+
+Do any of the followings changes break current behaviour or configuration?
+
+- **YES** / NO
+
+## How changes have been tested
+
+-
+
+## List any unknowns
+
+-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
           fail_on_error: true
           hadolint_ignore: DL3016 DL3018 # Ignore pinning apk and npm packages to specific version with @
 
-  actionlint:
+  lint-actions:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: Lint
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  lint-bash:
+    name: Lint Bash scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: shellcheck
+          level: warning
+          path: .
+          pattern: '*.sh'
+          fail_on_error: true
+
+  lint-dockerfile:
+    name: Lint Dockerfiles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: hadolint
+        uses: reviewdog/action-hadolint@v1
+        with:
+          level: warning
+          fail_on_error: true
+          hadolint_ignore: DL3016 DL3018 # Ignore pinning apk and npm packages to specific version with @

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.github_token }}
-          reporter: shellcheck
+          reporter: github-pr-review
           level: warning
           path: .
           pattern: '*.sh'
@@ -30,6 +30,7 @@ jobs:
       - name: hadolint
         uses: reviewdog/action-hadolint@v1
         with:
+          reporter: github-pr-review
           level: warning
           fail_on_error: true
           hadolint_ignore: DL3016 DL3018 # Ignore pinning apk and npm packages to specific version with @

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,11 @@ name: Lint
 
 on:
   pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
   workflow_dispatch:
 
 permissions:
@@ -34,3 +39,15 @@ jobs:
           level: warning
           fail_on_error: true
           hadolint_ignore: DL3016 DL3018 # Ignore pinning apk and npm packages to specific version with @
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Lint Github Actions
+        uses: reviewdog/action-actionlint@v1
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          reporter: github-pr-review

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
     - name: Bump version and push tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:12-alpine3.15
+FROM node:16-alpine
 LABEL "repository"="https://github.com/anothrNick/github-tag-action"
 LABEL "homepage"="https://github.com/anothrNick/github-tag-action"
 LABEL "maintainer"="Nick Sjostrom"
 
-RUN apk update && apk add bash git curl jq && npm install -g semver
+RUN apk --no-cache add bash git curl jq && npm install -g semver
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@1.36.0
+      uses: anothrNick/github-tag-action@1.40.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
 ```
 
-_NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all commits to look for the semver commit message._
+_NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you retrieve all commits to look for the semver commit message._
 
 #### Options
 


### PR DESCRIPTION
- Add minimal PR template
- Update docs to pin checkout action to v3
- Update node docker image from 12 to 16 (Fixes https://github.com/anothrNick/github-tag-action/issues/172)
- Add bash linting (on PR) (Fixes https://github.com/anothrNick/github-tag-action/issues/171)
- Add dockerfile linting (on PR)
- Add Github Actions linting (on PR)
- Update apk install to best practice --no-cache option