### PR TITLE
Hotfix: remove v check for major tag 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           git fetch --tags
           tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
           tag="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$tagFmt" | head -n 1)"
-          [[ "$tag" =~ ^(v[0-9]+) ]]
+          [[ "$tag" =~ ^([0-9]+) ]] # use ^(v[0-9]+) for vX
           major=${BASH_REMATCH[1]}
           # update major tag
           git tag -f "$major"


### PR DESCRIPTION
regex had v requirement

@sammcj sorry and thanks for the quick reviews, not my best day today missing the V vs non-V formats