### PR TITLE
Revert "fix: safe sub directory"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ suffix=${PRERELEASE_SUFFIX:-beta}
 verbose=${VERBOSE:-true}
 verbose=${VERBOSE:-true}
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
-git config --global --add safe.directory ${GITHUB_WORKSPACE}/${source}
+git config --global --add safe.directory /github/workspace
 
 cd ${GITHUB_WORKSPACE}/${source}
 


### PR DESCRIPTION
Reverts anothrNick/github-tag-action#149

This seems to have caused issues for some users that have had to downgrade to the previous release.

- https://github.com/anothrNick/github-tag-action/issues/182
- https://github.com/anothrNick/github-tag-action/issues/181