### PR TITLE
Print actual tag to be used when using `with_v`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,11 +158,11 @@ then
     fi
     part="pre-$part"
 else
-    echo -e "Bumping tag $tag. New tag ${new}"
     if $with_v
     then
         new="v$new"
     fi
+    echo -e "Bumping tag ${tag}. New tag ${new}"
 fi
 
 # as defined in readme if CUSTOM_TAG is used any semver calculations are irrelevant.


### PR DESCRIPTION
# Summary of changes

The logs from the tag run don't show the actual tag to be used if the
`with_v` option is set. This fixes that.

Do any of the followings changes break current behaviour or configuration?

- YES / **NO**

## How changes have been tested

-

## List any unknowns

-
