### PR TITLE
Update entrypoint.sh, by adding new_tag value when there are no new commits

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -96,6 +96,7 @@ commit=$(git rev-parse HEAD)
 if [ "$tag_commit" == "$commit" ]
 then
     echo "No new commits since previous tag. Skipping..."
+    echo "::set-output name=new_tag::$tag"
     echo "::set-output name=tag::$tag"
     exit 0
 fi


### PR DESCRIPTION
Adding **new_tag** variable when **tag_commit** is equal **commit**,  where solves some issues when there aren't new commits, it needs to take the previous existing tag.

# Summary of changes

Do any of the following changes break current behaviour or configuration?

- **NO**

## How changes have been tested
On my personal project, I was facing an issue related to the tags and I checked that one of my branches didn't have a new commit, and then I realized that the new tag was missing because it wasn't being set by getting the previous tag.
