### PR TITLE
Fix wildcard filters for branches

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,8 +36,13 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 pre_release="true"
 IFS=',' read -ra branch <<< "$release_branches"
 for b in "${branch[@]}"; do
-    # check if ${current_branch} is in ${release_branches}
-    if [[ "$current_branch" == "$b" ]]
+    # check if ${current_branch} is in ${release_branches} | exact branch match
+    if [[ "$current_branch" == "$b" ]] || [[ "$current_branch" =~ $b ]]
+    then
+        pre_release="false"
+    fi
+    # verify non specific branch names like  .* release/* if wildcard filter then =~
+    if [ "$b" != "${b//[\[\]|.? +*]/}" ] && [[ "$current_branch" =~ $b ]]
     then
         pre_release="false"
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ pre_release="true"
 IFS=',' read -ra branch <<< "$release_branches"
 for b in "${branch[@]}"; do
     # check if ${current_branch} is in ${release_branches} | exact branch match
-    if [[ "$current_branch" == "$b" ]] || [[ "$current_branch" =~ $b ]]
+    if [[ "$current_branch" == "$b" ]]
     then
         pre_release="false"
     fi


### PR DESCRIPTION
Separate from the == as can lead to unintended -like results unless a wildcard is specified in the list