### PR TITLE
Fix bump major release in self-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,3 +41,6 @@ jobs:
           # update major tag
           git tag -f "$major"
           git push -f origin "$major"
+          # add vX as 1 is linked to short sha bug https://github.com/anothrNick/github-tag-action/actions/runs/3139501775/jobs/5099976842#step:1:35
+          git tag -f "v$major"
+          git push -f origin "v$major"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: version-tag
         id: tag
-        uses: anothrNick/github-tag-action@1 # another pr require to move this to 1
+        uses: anothrNick/github-tag-action@1.47.0 # if we use 1 there is a too-be-fixed bug https://github.com/anothrNick/github-tag-action/actions/runs/3139501775/jobs/5099976842#step:1:35
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Seems to be a bug does not allow to use self major while bumping major in this repo. Makes sense though https://github.com/anothrNick/github-tag-action/actions/runs/3139501775/jobs/5099976842#step:1:35

Major does not work in referenced projects. So seems to be a github `@1` resolution thinking is a sha and not a tag

@sammcj merge once approved if I'm not around