### PR TITLE
Custom major, minor, patch, none commit message string token

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
 - **TAG_CONTEXT** _(optional)_ - Set the context of the previous tag. Possible values are `repo` (default) or `branch`.
 - **PRERELEASE_SUFFIX** _(optional)_ - Suffix for your prerelease versions, `beta` by default. Note this will only be used if a prerelease branch.
 - **VERBOSE** _(optional)_ - Print git logs. For some projects these logs may be very large. Possible values are `true` (default) and `false`.
+- **MAJOR_STRING_TOKEN** _(optional)_ - Change the default `#major` commit message string tag.
+- **MINOR_STRING_TOKEN** _(optional)_ - Change the default `#minor` commit message string tag.
+- **PATCH_STRING_TOKEN** _(optional)_ - Change the default `#patch` commit message string tag.
+- **NONE_STRING_TOKEN** _(optional)_ - Change the default `#none` commit message string tag.
 
 #### Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,9 +121,9 @@ then
 fi
 
 case "$log" in
-    *$major_string_token* ) new=$(semver -i major $tag); part="major";;
-    *$minor_string_token* ) new=$(semver -i minor $tag); part="minor";;
-    *$patch_string_token* ) new=$(semver -i patch $tag); part="patch";;
+    *$major_string_token* ) new=$(semver -i major "$tag"); part="major";;
+    *$minor_string_token* ) new=$(semver -i minor "$tag"); part="minor";;
+    *$patch_string_token* ) new=$(semver -i patch "$tag"); part="patch";;
     *$none_string_token* ) 
         echo "Default bump was set to none. Skipping..."
         echo "::set-output name=new_tag::$tag"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,10 @@ tag_context=${TAG_CONTEXT:-repo}
 suffix=${PRERELEASE_SUFFIX:-beta}
 verbose=${VERBOSE:-true}
 verbose=${VERBOSE:-true}
+major_string_token=${MAJOR_STRING_TOKEN:-#major}
+minor_string_token=${MINOR_STRING_TOKEN:-#minor}
+patch_string_token=${PATCH_STRING_TOKEN:-#patch}
+none_string_token=${NONE_STRING_TOKEN:-#none}
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
 git config --global --add safe.directory /github/workspace
 
@@ -30,6 +34,10 @@ echo -e "\tINITIAL_VERSION: ${initial_version}"
 echo -e "\tTAG_CONTEXT: ${tag_context}"
 echo -e "\tPRERELEASE_SUFFIX: ${suffix}"
 echo -e "\tVERBOSE: ${verbose}"
+echo -e "\tMAJOR_STRING_TOKEN: ${major_string_token}"
+echo -e "\tMINOR_STRING_TOKEN: ${minor_string_token}"
+echo -e "\tPATCH_STRING_TOKEN: ${patch_string_token}"
+echo -e "\tNONE_STRING_TOKEN: ${none_string_token}"
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
@@ -113,10 +121,10 @@ then
 fi
 
 case "$log" in
-    *#major* ) new=$(semver -i major "$tag"); part="major";;
-    *#minor* ) new=$(semver -i minor "$tag"); part="minor";;
-    *#patch* ) new=$(semver -i patch "$tag"); part="patch";;
-    *#none* ) 
+    *$major_string_token* ) new=$(semver -i major $tag); part="major";;
+    *$minor_string_token* ) new=$(semver -i minor $tag); part="minor";;
+    *$patch_string_token* ) new=$(semver -i patch $tag); part="patch";;
+    *$none_string_token* ) 
         echo "Default bump was set to none. Skipping..."
         echo "::set-output name=new_tag::$tag"
         echo "::set-output name=tag::$tag"


### PR DESCRIPTION
# Summary of changes

This PR add an option to choose custom string token to be considered as `#major`, `#minor`, `#patch`, `#none`. With the change and new configuration introduced, one could define their own repo convention.  As an example, one could set the `MINOR_STRING_TOKEN` config to `[minor]`, `[MINOR]`, `(minor)`, or `<minor>` to trigger minor version bump. It doesn't even have to contain the keyword "minor".

Do any of the followings changes break current behaviour or configuration?

- YES / **NO**

## How changes have been tested

```shell
#!/bin/bash

major_string_token=${MAJOR_STRING_TOKEN:-#major}
minor_string_token=${MINOR_STRING_TOKEN:-#minor}
patch_string_token=${PATCH_STRING_TOKEN:-#patch}
none_string_token=${NONE_STRING_TOKEN:-#none}

log="commit message string #minor [major]"

case "$log" in
    *$major_string_token* ) part="major";;
    *$minor_string_token* ) part="minor";;
    *$patch_string_token* ) part="patch";;
    *$none_string_token* ) part="none";;
    * ) 
        part="default"
        ;;
esac

echo $part
```

Using snippet above as illustration, existing behavior without additional configuration will trigger **minor** version bump. Should the `MAJOR_STRING_TOKEN` configured to `[major]`, will trigger **major** version bump.

## List any unknowns
- 