### PR TITLE
Change log ack from all logs to merge commit log

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,6 @@ on:
       - edited
       - reopened
       - synchronize
-  workflow_dispatch:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,11 @@
 name: Bump version
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - master
-    paths-ignore:
-      - '.github/**'
 
 jobs:
   build:
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: '0'
 
       - name: version-tag

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: version-tag
         id: tag
-        uses: anothrNick/github-tag-action@1.47.0 # if we use 1 there is a too-be-fixed bug https://github.com/anothrNick/github-tag-action/actions/runs/3139501775/jobs/5099976842#step:1:35
+        uses: anothrNick/github-tag-action@1.51.0 # if we use 1 there is a too-be-fixed bug https://github.com/anothrNick/github-tag-action/actions/runs/3139501775/jobs/5099976842#step:1:35
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,8 +66,6 @@ jobs:
           echo "PRE New tag: $PRE_OUTPUT_NEWTAG" >> $GITHUB_STEP_SUMMARY
           echo "PRE Part: $PRE_OUTPUT_PART" >> $GITHUB_STEP_SUMMARY
 
-
-
           # check that the original tag got bumped either major, minor, patch
           verlte() {
             [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
@@ -76,8 +74,8 @@ jobs:
             [ "$1" = "$2" ] && return 1 || verlte $1 $2
           }
 
-          main=$(verlt $MAIN_OUTPUT_TAG $MAIN_OUTPUT_NEWTAG && true || false)
-          pre=$(verlt $PRE_OUTPUT_TAG $PRE_OUTPUT_NEWTAG && true || false)
+          main="$(verlt $MAIN_OUTPUT_TAG $MAIN_OUTPUT_NEWTAG && true || false)"
+          pre="$(verlt $PRE_OUTPUT_TAG $PRE_OUTPUT_NEWTAG && true || false)"
 
           if $main && $pre
             echo "The tags were created correctly" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           DRY_RUN: true
           WITH_V: true
+          PRERELEASE: true
           PRERELEASE_SUFFIX: test
           VERBOSE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +76,7 @@ jobs:
           b[2]=0
           PRE_CORRECT_TAG="v${b[0]}.${b[1]}.${b[2]}-test.0"
 
-          if [[ $MAIN_OUTPUT_NEWTAG == $MAIN_CORRECT_TAG ]] || [[ $PRE_OUTPUT_NEWTAG == $PRE_CORRECT_TAG ]]; then
+          if [[ $MAIN_OUTPUT_NEWTAG == $MAIN_CORRECT_TAG ]] && [[ $PRE_OUTPUT_NEWTAG == $PRE_CORRECT_TAG ]]; then
             echo "The tag was created correctly" >> $GITHUB_STEP_SUMMARY
           else
             echo "The tag was not created correctly" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,21 +66,25 @@ jobs:
           echo "PRE New tag: $PRE_OUTPUT_NEWTAG" >> $GITHUB_STEP_SUMMARY
           echo "PRE Part: $PRE_OUTPUT_PART" >> $GITHUB_STEP_SUMMARY
 
-          # Work out what the new tag should be
-          a=( ${MAIN_OUTPUT_TAG//./ } )
-          ((a[1]++))
-          a[2]=0
-          MAIN_CORRECT_TAG="v${a[0]}.${a[1]}.${a[2]}"
 
-          b=( ${PRE_OUTPUT_TAG//./ } )
-          ((b[1]++))
-          b[2]=0
-          PRE_CORRECT_TAG="v${b[0]}.${b[1]}.${b[2]}-test.0"
 
-          if [[ $MAIN_OUTPUT_NEWTAG == $MAIN_CORRECT_TAG ]] && [[ $PRE_OUTPUT_NEWTAG == $PRE_CORRECT_TAG ]]; then
-            echo "The tag was created correctly" >> $GITHUB_STEP_SUMMARY
+          # check that the original tag got bumped either major, minor, patch
+          verlte() {
+            [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+          }
+          verlt() {
+            [ "$1" = "$2" ] && return 1 || verlte $1 $2
+          }
+
+          main=$(verlt $MAIN_OUTPUT_TAG $MAIN_OUTPUT_NEWTAG && true || false)
+          pre=$(verlt $PRE_OUTPUT_TAG $PRE_OUTPUT_NEWTAG && true || false)
+
+          if $main && $pre
+            echo "The tags were created correctly" >> $GITHUB_STEP_SUMMARY
           else
-            echo "The tag was not created correctly" >> $GITHUB_STEP_SUMMARY
+            echo "Tags not created correctly" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+
+          # todo add test for #none bump
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,17 @@ jobs:
           fetch-depth: '0'
 
       # Use the action to generate a tag for itself
-      - name: Test action
+      - name: Test action main
+        id: test
+        uses: ./
+        env:
+          DRY_RUN: true
+          WITH_V: true
+          VERBOSE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Use the action to generate a tag for itself
+      - name: Test action pre-release
         id: test
         uses: ./
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
       # Use the action to generate a tag for itself
       - name: Test action main
-        id: test
+        id: test_main
         uses: ./
         env:
           DRY_RUN: true
@@ -36,7 +36,7 @@ jobs:
 
       # Use the action to generate a tag for itself
       - name: Test action pre-release
-        id: test
+        id: test_pre
         uses: ./
         env:
           DRY_RUN: true
@@ -49,25 +49,36 @@ jobs:
       - name: Check if the tag would have been created
         shell: bash
         run: |
-          OUTPUT_TAG=${{ steps.test.outputs.tag }}
-          OUTPUT_NEWTAG=${{ steps.test.outputs.new_tag }}
-          OUTPUT_PART=${{ steps.test.outputs.part }}
+          MAIN_OUTPUT_TAG=${{ steps.test_main.outputs.tag }}
+          MAIN_OUTPUT_NEWTAG=${{ steps.test_main.outputs.new_tag }}
+          MAIN_OUTPUT_PART=${{ steps.test_main.outputs.part }}
+          PRE_OUTPUT_TAG=${{ steps.test_pre.outputs.tag }}
+          PRE_OUTPUT_NEWTAG=${{ steps.test_pre.outputs.new_tag }}
+          PRE_OUTPUT_PART=${{ steps.test_pre.outputs.part }}
 
           echo "Outputs from running the action:" >> $GITHUB_STEP_SUMMARY
-          echo "Tag: $OUTPUT_TAG" >> $GITHUB_STEP_SUMMARY
-          echo "New tag: $OUTPUT_NEWTAG" >> $GITHUB_STEP_SUMMARY
-          echo "Part: $OUTPUT_PART" >> $GITHUB_STEP_SUMMARY
+          echo "MAIN Tag: $MAIN_OUTPUT_TAG" >> $GITHUB_STEP_SUMMARY
+          echo "MAIN New tag: $MAIN_OUTPUT_NEWTAG" >> $GITHUB_STEP_SUMMARY
+          echo "MAIN Part: $MAIN_OUTPUT_PART" >> $GITHUB_STEP_SUMMARY
+          echo "PRE Tag: $PRE_OUTPUT_TAG" >> $GITHUB_STEP_SUMMARY
+          echo "PRE New tag: $PRE_OUTPUT_NEWTAG" >> $GITHUB_STEP_SUMMARY
+          echo "PRE Part: $PRE_OUTPUT_PART" >> $GITHUB_STEP_SUMMARY
 
           # Work out what the new tag should be
-          a=( ${OUTPUT_TAG//./ } )
+          a=( ${MAIN_OUTPUT_TAG//./ } )
           ((a[1]++))
           a[2]=0
-          CORRECT_TAG="v${a[0]}.${a[1]}.${a[2]}-test.0"
+          MAIN_CORRECT_TAG="v${a[0]}.${a[1]}.${a[2]}"
 
-          if [[ $OUTPUT_NEWTAG == $CORRECT_TAG ]]; then
+          b=( ${PRE_OUTPUT_TAG//./ } )
+          ((b[1]++))
+          b[2]=0
+          PRE_CORRECT_TAG="v${b[0]}.${b[1]}.${b[2]}-test.0"
+
+          if [[ $MAIN_OUTPUT_NEWTAG == $MAIN_CORRECT_TAG ]] || [[ $PRE_OUTPUT_NEWTAG == $PRE_CORRECT_TAG ]]; then
             echo "The tag was created correctly" >> $GITHUB_STEP_SUMMARY
           else
-            echo "The tag was not created correctly, expected $CORRECT_TAG got $OUTPUT_NEWTAG" >> $GITHUB_STEP_SUMMARY
+            echo "The tag was not created correctly" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Check if the tag would have been created
         shell: bash
         run: |
+          set -x
           MAIN_OUTPUT_TAG=${{ steps.test_main.outputs.tag }}
           MAIN_OUTPUT_NEWTAG=${{ steps.test_main.outputs.new_tag }}
           MAIN_OUTPUT_PART=${{ steps.test_main.outputs.part }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
           pre="$(verlt $PRE_OUTPUT_TAG $PRE_OUTPUT_NEWTAG && true || false)"
 
           if $main && $pre
+          then
             echo "The tags were created correctly" >> $GITHUB_STEP_SUMMARY
           else
             echo "Tags not created correctly" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
       - edited
       - reopened
       - synchronize
-  workflow_dispatch:
 
 permissions:
   pull-requests: write
@@ -22,6 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: '0'
 
       # Use the action to generate a tag for itself

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
         WITH_V: true
 ```
 
-**Depending if you choose example 1 or example 2 is how crafter bumps operate when reading the commit log. Is recommended to use on `pull_request` instead of on commit to master/main.**
+**Depending if you choose example 1 or example 2 is how crafted bumps operate when reading the commit log. Is recommended to use on `pull_request` instead of on commit to master/main.**
 
 _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you retrieve all commits to look for the semver commit message._
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A Github Action to automatically bump and tag master, on merge, with the latest 
 
 ### Usage
 
-```Dockerfile
+```yaml
+# example 1: on push to master
 name: Bump version
 on:
   push:
@@ -25,12 +26,40 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
+
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
 ```
+
+```yaml
+# example 2: on merge to master
+name: Bump version
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: '0'
+
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+```
+
+**Depending if you choose example 1 or example 2 is how crafter bumps operate when reading the commit log. Is recommended to use on `pull_request` instead of on commit to master/main.**
 
 _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you retrieve all commits to look for the semver commit message._
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
 - **DRY_RUN** _(optional)_ - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are `true` and `false` (default).
 - **INITIAL_VERSION** _(optional)_ - Set initial version before bump. Default `0.0.0`.
 - **TAG_CONTEXT** _(optional)_ - Set the context of the previous tag. Possible values are `repo` (default) or `branch`.
+- **PRERELEASE** _(optional)_ - Define if workflow runs on prerelease flag or not, `false` by default. Note this will be overwritten if using complex suffix release branches.
 - **PRERELEASE_SUFFIX** _(optional)_ - Suffix for your prerelease versions, `beta` by default. Note this will only be used if a prerelease branch.
 - **VERBOSE** _(optional)_ - Print git logs. For some projects these logs may be very large. Possible values are `true` (default) and `false`.
 - **MAJOR_STRING_TOKEN** _(optional)_ - Change the default `#major` commit message string tag.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
 - **DRY_RUN** _(optional)_ - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are `true` and `false` (default).
 - **INITIAL_VERSION** _(optional)_ - Set initial version before bump. Default `0.0.0`.
 - **TAG_CONTEXT** _(optional)_ - Set the context of the previous tag. Possible values are `repo` (default) or `branch`.
-- **PRERELEASE** _(optional)_ - Define if workflow runs on prerelease flag or not, `false` by default. Note this will be overwritten if using complex suffix release branches.
+- **PRERELEASE** _(optional)_ - Define if workflow runs in prerelease mode, `false` by default. Note this will be overwritten if using complex suffix release branches.
 - **PRERELEASE_SUFFIX** _(optional)_ - Suffix for your prerelease versions, `beta` by default. Note this will only be used if a prerelease branch.
 - **VERBOSE** _(optional)_ - Print git logs. For some projects these logs may be very large. Possible values are `true` (default) and `false`.
 - **MAJOR_STRING_TOKEN** _(optional)_ - Change the default `#major` commit message string tag.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
         WITH_V: true
 ```
 
-**Depending if you choose example 1 or example 2 is how crafted bumps operate when reading the commit log. Is recommended to use on `pull_request` instead of on commit to master/main.**
+**Depending if you choose example 1 or example 2 is how crafted version bumps operate when reading the commit log. Is recommended to use on `pull_request` instead of on commit to master/main.**
 
 _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you retrieve all commits to look for the semver commit message._
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@1.40.0
+      uses: anothrNick/github-tag-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
@@ -65,9 +65,9 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
 ### Bumping
 
 **Manual Bumping:** Any commit message that includes `#major`, `#minor`, `#patch`, or `#none` will trigger the respective version bump. If two or more are present, the highest-ranking one will take precedence.
-If `#none` is contained in the commit message, it will skip bumping regardless `DEFAULT_BUMP`.
+If `#none` is contained in the merge commit message, it will skip bumping regardless `DEFAULT_BUMP`.
 
-**Automatic Bumping:** If no `#major`, `#minor` or `#patch` tag is contained in the commit messages, it will bump whichever `DEFAULT_BUMP` is set to (which is `minor` by default). Disable this by setting `DEFAULT_BUMP` to `none`.
+**Automatic Bumping:** If no `#major`, `#minor` or `#patch` tag is contained in the merge commit message, it will bump whichever `DEFAULT_BUMP` is set to (which is `minor` by default). Disable this by setting `DEFAULT_BUMP` to `none`.
 
 > **_Note:_** This action **will not** bump the tag if the `HEAD` commit has already been tagged.
 
@@ -78,7 +78,7 @@ If `#none` is contained in the commit message, it will skip bumping regardless `
 - Either push to master or open a PR
 - On push (or merge), the action will:
   - Get latest tag
-  - Bump tag with minor version unless any commit message contains `#major` or `#patch`
+  - Bump tag with minor version unless the merge commit message contains `#major` or `#patch`
   - Pushes tag to github
   - If triggered on your repo's default branch (`master` or `main` if unchanged), the bump version will be a release tag.
   - If triggered on any other branch, a prerelease will be generated, depending on the bump, starting with `*-<PRERELEASE_SUFFIX>.1`, `*-<PRERELEASE_SUFFIX>.2`, ...

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -118,6 +118,7 @@ fi
 
 # get the merge commit message looking for #bumps
 log=$(git log -1 --pretty='%B' --)
+echo "Last commit message: $log"
 
 case "$log" in
     *$major_string_token* ) new=$(semver -i major "$tag"); part="major";;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -182,9 +182,9 @@ fi
 # set outputs
 echo "::set-output name=new_tag::$new"
 echo "::set-output name=part::$part"
-echo "::set-output name=tag::$new"
+echo "::set-output name=tag::$tag"
 
-# use dry run to determine the next tag
+# dry run exit without real changes
 if $dryrun
 then
     exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ source=${SOURCE:-.}
 dryrun=${DRY_RUN:-false}
 initial_version=${INITIAL_VERSION:-0.0.0}
 tag_context=${TAG_CONTEXT:-repo}
+prerelease=${PRERELEASE:-false}
 suffix=${PRERELEASE_SUFFIX:-beta}
 verbose=${VERBOSE:-true}
 major_string_token=${MAJOR_STRING_TOKEN:-#major}
@@ -31,6 +32,7 @@ echo -e "\tSOURCE: ${source}"
 echo -e "\tDRY_RUN: ${dryrun}"
 echo -e "\tINITIAL_VERSION: ${initial_version}"
 echo -e "\tTAG_CONTEXT: ${tag_context}"
+echo -e "\tPRERELEASE: ${prerelease}"
 echo -e "\tPRERELEASE_SUFFIX: ${suffix}"
 echo -e "\tVERBOSE: ${verbose}"
 echo -e "\tMAJOR_STRING_TOKEN: ${major_string_token}"
@@ -46,7 +48,7 @@ fi
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
-pre_release="true"
+pre_release="$prerelease"
 IFS=',' read -ra branch <<< "$release_branches"
 for b in "${branch[@]}"; do
     # check if ${current_branch} is in ${release_branches} | exact branch match
@@ -145,7 +147,7 @@ esac
 
 if $pre_release
 then
-    # Already a prerelease available, bump it
+    # already a pre-release available, bump it
     if [[ "$pre_tag" =~ $new ]] && [[ "$pre_tag" =~ $suffix ]]
     then
         if $with_v

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -162,7 +162,7 @@ then
         else
             new="$new-$suffix.0"
         fi
-        echo -e "Setting ${suffix} pre-tag ${pre_tag}. With pre-tag ${new}"
+        echo -e "Setting ${suffix} pre-tag ${pre_tag} - With pre-tag ${new}"
     fi
     part="pre-$part"
 else
@@ -170,7 +170,7 @@ else
     then
         new="v$new"
     fi
-    echo -e "Bumping tag ${tag}. New tag ${new}"
+    echo -e "Bumping tag ${tag} - New tag ${new}"
 fi
 
 # as defined in readme if CUSTOM_TAG is used any semver calculations are irrelevant.
@@ -182,15 +182,13 @@ fi
 # set outputs
 echo "::set-output name=new_tag::$new"
 echo "::set-output name=part::$part"
+echo "::set-output name=tag::$new"
 
 # use dry run to determine the next tag
 if $dryrun
 then
-    echo "::set-output name=tag::$tag"
     exit 0
-fi 
-
-echo "::set-output name=tag::$new"
+fi
 
 # create local git tag
 git tag "$new"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -117,7 +117,7 @@ then
 fi
 
 # get the merge commit message looking for #bumps
-log=$(git log -1 --pretty='%B' --)
+log=$(git show -s --format=%s)
 echo "Last commit message: $log"
 
 case "$log" in


### PR DESCRIPTION
Solves https://github.com/anothrNick/github-tag-action/issues/194

I personally think this should be the expected behaviour when we merge we define the future of this branch bump in the merge commit message not necessarily by a random commit lost down in the commit history making it hard to track.