### PR TITLE
Use master for auto releasing this repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: version-tag
         id: tag
-        uses: anothrNick/github-tag-action@1.51.0 # if we use 1 there is a too-be-fixed bug https://github.com/anothrNick/github-tag-action/actions/runs/3139501775/jobs/5099976842#step:1:35
+        uses: anothrNick/github-tag-action@master # if we use 1 there is a too-be-fixed bug https://github.com/anothrNick/github-tag-action/actions/runs/3139501775/jobs/5099976842#step:1:35 alternatvelly we can use v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
With the current history log using bump tags we cannot get a new 1 and v1 tag bump unless we use the last commit which is using version 1.52.0 or later.

I think is safe to use master there. As we test in latest:master.

![image](https://user-images.githubusercontent.com/23391642/193757445-94cce85f-56dc-4701-b592-7ebdc0b86c95.png)
1 and v1 are failing due wrong interpretation of commit history bumps https://github.com/anothrNick/github-tag-action/actions/runs/3180053697/jobs/5183196350 

@sammcj  merge once approved.