### PR TITLE
Hotfix: sort output tag mismatch reverting breaking change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,13 +25,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # auto releases is not working atm and is deleting releases due branch tags
-      #- name: automatic-draft-release
-      #  uses: marvinpinto/action-automatic-releases@v1.2.1
-      #  with:
-      #    draft: true
-      #    repo_token: ${{ secrets.GITHUB_TOKEN }}
-      #    title: "${{ steps.tag.outputs.tag }}: [title-edit-me] by:${{ github.actor }}"
-      #    automatic_release_tag: ${{ steps.tag.outputs.tag }}
+      - name: automatic-draft-release
+        uses: marvinpinto/action-automatic-releases@v1.2.1
+        with:
+          draft: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          title: "${{ steps.tag.outputs.tag }}: [title-edit-me] by:${{ github.actor }}"
+          automatic_release_tag: ${{ steps.tag.outputs.new_tag }}
 
       - name: version-tag-major
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,13 @@ on:
 
 jobs:
   build:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: master
           fetch-depth: '0'
+          ref: ${{ github.ref_name }}
 
       - name: version-tag
         id: tag
@@ -23,13 +24,14 @@ jobs:
           VERBOSE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: automatic-draft-release
-        uses: marvinpinto/action-automatic-releases@v1.2.1
-        with:
-          draft: true
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          title: "${{ steps.tag.outputs.tag }}: [title-edit-me] by:${{ github.actor }}"
-          automatic_release_tag: ${{ steps.tag.outputs.tag }}
+      # auto releases is not working atm and is deleting releases due branch tags
+      #- name: automatic-draft-release
+      #  uses: marvinpinto/action-automatic-releases@v1.2.1
+      #  with:
+      #    draft: true
+      #    repo_token: ${{ secrets.GITHUB_TOKEN }}
+      #    title: "${{ steps.tag.outputs.tag }}: [title-edit-me] by:${{ github.actor }}"
+      #    automatic_release_tag: ${{ steps.tag.outputs.tag }}
 
       - name: version-tag-major
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,10 @@ jobs:
         shell: bash
         run: |
           set -x
-          MAIN_OUTPUT_TAG=${{ steps.test_main.outputs.tag }}
+          MAIN_OUTPUT_TAG=${{ steps.test_main.outputs.old_tag }}
           MAIN_OUTPUT_NEWTAG=${{ steps.test_main.outputs.new_tag }}
           MAIN_OUTPUT_PART=${{ steps.test_main.outputs.part }}
-          PRE_OUTPUT_TAG=${{ steps.test_pre.outputs.tag }}
+          PRE_OUTPUT_TAG=${{ steps.test_pre.outputs.old_tag }}
           PRE_OUTPUT_NEWTAG=${{ steps.test_pre.outputs.new_tag }}
           PRE_OUTPUT_PART=${{ steps.test_pre.outputs.part }}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -184,7 +184,8 @@ fi
 # set outputs
 echo "::set-output name=new_tag::$new"
 echo "::set-output name=part::$part"
-echo "::set-output name=tag::$tag"
+echo "::set-output name=tag::$new" # this needs to go in v2 is breaking change
+echo "::set-output name=old_tag::$tag"
 
 # dry run exit without real changes
 if $dryrun


### PR DESCRIPTION
Okay the problem here was output tag as replaced with $new tag and that is breaking change so added new output old_tag instead and left the tag output as was before untill v2 

https://github.com/anothrNick/github-tag-action/issues/200