### PR TITLE
feat: pre-build dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+#Ignore logs
+logs/
+*.log
+
+#Ignore the git and cache folders
+.git
+.cache
+
+#Ignore Temp files
+*.tmp

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,77 @@
+name: Build & Publish Docker Image
+
+# This workflow builds the prebuild.Dockerfile and publishes the image to the GitHub Container Registry if the build is successful.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+permissions:
+  packages: write
+  contents: read
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_TAG: ${{ github.sha }}
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    timeout-minutes: 15
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Generate Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          images: |
+            ${{ env.IMAGE_NAME }}
+            ghcr.io/user${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Set up QEMU To support build amd64 and arm64 images
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        id: docker_build
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          context: .
+          file: ./prebuild.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Output image, digest and metadata to summary
+        run: |
+          {
+          echo imageid: "${{ steps.docker_build.outputs.imageid }}"
+          echo digest: "${{ steps.docker_build.outputs.digest }}"
+          echo labels: "${{ steps.meta.outputs.labels }}"
+          echo tags: "${{ steps.meta.outputs.tags }}"
+          echo version: "${{ steps.meta.outputs.version }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - opened
@@ -16,7 +17,7 @@ permissions:
 jobs:
   lint-bash:
     name: Lint Bash scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: reviewdog/action-shellcheck@v1
@@ -25,12 +26,12 @@ jobs:
           reporter: github-pr-review
           level: warning
           path: .
-          pattern: '*.sh'
+          pattern: "*.sh"
           fail_on_error: true
 
   lint-dockerfile:
     name: Lint Dockerfiles
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: hadolint
@@ -42,7 +43,7 @@ jobs:
           hadolint_ignore: DL3016 DL3018 # Ignore pinning apk and npm packages to specific version with @
 
   lint-actions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Lint Github Actions
@@ -52,3 +53,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           reporter: github-pr-review
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tool_name: actionlint
+          level: warning
+          fail_on_error: true
+          filter_mode: added

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Bump version
 
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - closed
@@ -14,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
           ref: ${{ github.ref_name }}
 
       - name: version-tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ permissions:
   pull-requests: write
   checks: write
   contents: read
+  packages: read
 
 jobs:
   test-action:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 # This workflow tests the tag action and can be used on PRs to detect (some) breaking changes.
 
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - opened
@@ -16,13 +17,13 @@ permissions:
 
 jobs:
   test-action:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: '0'
+          fetch-depth: "0"
 
       # Use the action to generate a tag for itself
       - name: Test action main
@@ -86,4 +87,3 @@ jobs:
           fi
 
           # todo add test for #none bump
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # hadolint ignore=DL3007
-FROM ghcr.io/anothrNick/github-tag-action:latest
+FROM ghcr.io/anothrnick/github-tag-action:latest
 
-LABEL "repository"="https://github.com/anothrNick/github-tag-action"
-LABEL "homepage"="https://github.com/anothrNick/github-tag-action"
+LABEL "repository"="https://github.com/anothrnick/github-tag-action"
+LABEL "homepage"="https://github.com/anothrnick/github-tag-action"
 LABEL "maintainer"="Nick Sjostrom"
 
 # This Dockerfile is empty, it simply pulls a prebuilt image to speed up the Action.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM node:16-alpine
+# hadolint ignore=DL3007
+FROM ghcr.io/anothrNick/github-tag-action:latest
+
 LABEL "repository"="https://github.com/anothrNick/github-tag-action"
 LABEL "homepage"="https://github.com/anothrNick/github-tag-action"
 LABEL "maintainer"="Nick Sjostrom"
 
-RUN apk --no-cache add bash git curl jq && npm install -g semver
-
-COPY entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+# This Dockerfile is empty, it simply pulls a prebuilt image to speed up the Action.

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,16 @@
-name: 'Github Tag Bump'
-description: 'Bump and push git tag on merge'
-author: 'Nick Sjostrom'
+name: "Github Tag Bump"
+description: "Bump and push git tag on merge"
+author: "Nick Sjostrom"
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
 outputs:
   new_tag:
-    description: 'Generated tag'
+    description: "Generated tag"
   tag:
-    description: 'The latest tag after running this action'
+    description: "The latest tag after running this action"
   part:
-    description: 'The part of version which was bumped'
+    description: "The part of version which was bumped"
 branding:
-  icon: 'git-merge'  
-  color: 'purple'
+  icon: "git-merge"
+  color: "purple"

--- a/prebuild.Dockerfile
+++ b/prebuild.Dockerfile
@@ -1,0 +1,12 @@
+FROM node:16-alpine
+
+LABEL "repository"="https://github.com/anothrNick/github-tag-action"
+LABEL "homepage"="https://github.com/anothrNick/github-tag-action"
+LABEL "maintainer"="Nick Sjostrom"
+
+# hadolint ignore=DL3016,DL3018
+RUN apk --no-cache add bash git curl jq && npm install -g semver
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/prebuild.Dockerfile
+++ b/prebuild.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16-alpine
 
-LABEL "repository"="https://github.com/anothrNick/github-tag-action"
-LABEL "homepage"="https://github.com/anothrNick/github-tag-action"
+LABEL "repository"="https://github.com/anothrnick/github-tag-action"
+LABEL "homepage"="https://github.com/anothrnick/github-tag-action"
 LABEL "maintainer"="Nick Sjostrom"
 
 # hadolint ignore=DL3016,DL3018


### PR DESCRIPTION
# Summary of changes

Fix for https://github.com/anothrNick/github-tag-action/issues/163

- Build, label, tag and publish Docker image to Githubs image repository.
- Simplify Action's Dockerfile to pull the built image.

Do any of the followings changes break current behaviour or configuration?

- No

## How changes have been tested

- I've forked the repo and done the build and publish.
- Tested I'm able to pull the built image locally.


## List any unknowns

- I haven't tested the changes in _this_ repo.
	- I don't know what package permissions @anothrNick has setup on this repo, if it's default I believe public repos have public packages.

Once merged, the Action should be tested to ensure it's operating the same. 
