### PR TITLE
Update set-output to use GITHUB_OUTPUT file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,10 @@ then
     set -x
 fi
 
+setOutput() {
+    echo "${1}=${2}" >> ${GITHUB_OUTPUT}
+}
+
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 pre_release="$prerelease"
@@ -113,8 +117,8 @@ commit=$(git rev-parse HEAD)
 if [ "$tag_commit" == "$commit" ]
 then
     echo "No new commits since previous tag. Skipping..."
-    echo "::set-output name=new_tag::$tag"
-    echo "::set-output name=tag::$tag"
+    setOutput "new_tag" "$tag"
+    setOutput "tag" "$tag"
     exit 0
 fi
 
@@ -128,15 +132,15 @@ case "$log" in
     *$patch_string_token* ) new=$(semver -i patch "$tag"); part="patch";;
     *$none_string_token* ) 
         echo "Default bump was set to none. Skipping..."
-        echo "::set-output name=new_tag::$tag"
-        echo "::set-output name=tag::$tag"
+        setOutput "new_tag" "$tag"
+        setOutput "tag" "$tag"
         exit 0;;
     * ) 
         if [ "$default_semvar_bump" == "none" ]
         then
             echo "Default bump was set to none. Skipping..."
-            echo "::set-output name=new_tag::$tag"
-            echo "::set-output name=tag::$tag"
+            setOutput "new_tag" "$tag"
+            setOutput "tag" "$tag"
             exit 0 
         else 
             new=$(semver -i "${default_semvar_bump}" "$tag")
@@ -182,10 +186,10 @@ then
 fi
 
 # set outputs
-echo "::set-output name=new_tag::$new"
-echo "::set-output name=part::$part"
-echo "::set-output name=tag::$new" # this needs to go in v2 is breaking change
-echo "::set-output name=old_tag::$tag"
+setOutput "new_tag" "$new"
+setOutput "part" "$part"
+setOutput "tag" "$new"
+setOutput "old_tag" "$tag"
 
 # dry run exit without real changes
 if $dryrun

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,7 @@ then
 fi
 
 setOutput() {
-    echo "${1}=${2}" >> ${GITHUB_OUTPUT}
+    echo "${1}=${2}" >> "${GITHUB_OUTPUT}"
 }
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -188,7 +188,7 @@ fi
 # set outputs
 setOutput "new_tag" "$new"
 setOutput "part" "$part"
-setOutput "tag" "$new"  # this needs to go in v2 is breaking change
+setOutput "tag" "$new" # this needs to go in v2 is breaking change
 setOutput "old_tag" "$tag"
 
 # dry run exit without real changes

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -188,7 +188,7 @@ fi
 # set outputs
 setOutput "new_tag" "$new"
 setOutput "part" "$part"
-setOutput "tag" "$new"
+setOutput "tag" "$new"  # this needs to go in v2 is breaking change
 setOutput "old_tag" "$tag"
 
 # dry run exit without real changes


### PR DESCRIPTION
Resolves #205 

# Summary of changes

Updates how output is being set to remove warnings and prevent breakage once Github removes support for the `set-output` echo statements.

Do any of the followings changes break current behaviour or configuration?

- **NO**

## How changes have been tested

- Tested locally by setting the environment variable to `/dev/stdout` to see the correct output.
- `test.yml` workflow should validate the functionality by executing this changed action.

## List any unknowns

- Should not be any unknowns, as this is following Github's documentation on how to set outputs as of 2022-10-11