### PR TITLE
Revert log assignment

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,7 +119,7 @@ then
 fi
 
 # get the merge commit message looking for #bumps
-log=$(git show -s --format=%s)
+log=$(git show -s "$tag"..HEAD --format=%s)
 echo "Last commit message: $log"
 
 case "$log" in


### PR DESCRIPTION
# Summary of changes
Revert `log` assignment to examine a range of commits. The existing command (`git show -s --format=%s`) only shows a single entry:

```
$ git show -s --format=%s       
fix log list
```

with fix (using `1.51.0` as a reference tag):
```
$ git show -s 1.51.0..HEAD --format=%s
fix log list
Merge pull request #199 from anothrNick/hotfix/sorttags
we introduced a breaking change in outputs rolling back with hotfix
sort tags skip draf releases
```
Do any of the followings changes break current behaviour or configuration?

- NO

## How changes have been tested
Execution in local bash shell
-

## List any unknowns
n/a
-
