### PR TITLE
FIX: use git tag / git push instead of http soft tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           VERBOSE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_API_TAGGING: false # uses git cli
 
       # auto releases is not working atm and is deleting releases due branch tags
       - name: automatic-draft-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,16 @@ jobs:
           DEFAULT_BUMP: none
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Test action main5 (with_v true)
+        id: test_main5
+        uses: ./
+        env:
+          DRY_RUN: true
+          WITH_V: true
+          VERBOSE: true
+          DEFAULT_BUMP: patch
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Use the action to generate a tag for itself
       - name: Test action pre1-release (with_v true)
         id: test_pre1
@@ -118,6 +128,10 @@ jobs:
           MAIN4_OUTPUT_NEWTAG=${{ steps.test_main4.outputs.new_tag }}
           MAIN4_OUTPUT_PART=${{ steps.test_main4.outputs.part }}
 
+          MAIN5_OUTPUT_TAG=${{ steps.test_main5.outputs.old_tag }}
+          MAIN5_OUTPUT_NEWTAG=${{ steps.test_main5.outputs.new_tag }}
+          MAIN5_OUTPUT_PART=${{ steps.test_main5.outputs.part }}
+
           echo -e "> MAIN tests with_v, default bump:\n" >> $GITHUB_STEP_SUMMARY
 
           echo "MAIN1 with_v Tag: $MAIN1_OUTPUT_TAG" >> $GITHUB_STEP_SUMMARY
@@ -154,6 +168,12 @@ jobs:
           echo "MAIN4 with_v New tag: $MAIN4_OUTPUT_NEWTAG" >> $GITHUB_STEP_SUMMARY
           echo "MAIN4 with_v Part: $MAIN4_OUTPUT_PART" >> $GITHUB_STEP_SUMMARY
 
+          echo -e "> MAIN tests with_v, bump patch:\n" >> $GITHUB_STEP_SUMMARY
+
+          echo "MAIN5 with_v Tag: $MAIN5_OUTPUT_TAG" >> $GITHUB_STEP_SUMMARY
+          echo "MAIN5 with_v New tag: $MAIN5_OUTPUT_NEWTAG" >> $GITHUB_STEP_SUMMARY
+          echo "MAIN5 with_v Part: $MAIN5_OUTPUT_PART" >> $GITHUB_STEP_SUMMARY
+
           # check that the original tag got bumped either major, minor, patch
           verlte() {
             [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
@@ -171,6 +191,7 @@ jobs:
           # needs to be the latest tag of the repo when bump is none
           main3="$([ "$MAIN3_OUTPUT_TAG" = "$MAIN3_OUTPUT_NEWTAG" ] && true || false)"
           main4="$([ "$MAIN4_OUTPUT_TAG" = "$MAIN4_OUTPUT_NEWTAG" ] && true || false)"
+          main5="$([ "$MAIN5_OUTPUT_TAG" = "$MAIN5_OUTPUT_NEWTAG" ] && true || false)"
 
           if $main1 && $pre1 && $main2 && $pre2 && $main3 && $main4
           then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,7 +193,7 @@ jobs:
           main4="$([ "$MAIN4_OUTPUT_TAG" = "$MAIN4_OUTPUT_NEWTAG" ] && true || false)"
           main5="$([ "$MAIN5_OUTPUT_TAG" = "$MAIN5_OUTPUT_NEWTAG" ] && true || false)"
 
-          if $main1 && $pre1 && $main2 && $pre2 && $main3 && $main4
+          if $main1 && $pre1 && $main2 && $pre2 && $main3 && $main4 && $main5
           then
             echo -e "\n>>>>The tags were created correctly" >> $GITHUB_STEP_SUMMARY
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,7 +191,8 @@ jobs:
           # needs to be the latest tag of the repo when bump is none
           main3="$([ "$MAIN3_OUTPUT_TAG" = "$MAIN3_OUTPUT_NEWTAG" ] && true || false)"
           main4="$([ "$MAIN4_OUTPUT_TAG" = "$MAIN4_OUTPUT_NEWTAG" ] && true || false)"
-          main5="$([ "$MAIN5_OUTPUT_TAG" = "$MAIN5_OUTPUT_NEWTAG" ] && true || false)"
+          # needs to be a greater tag in bump patch
+          main5="$(verlt $MAIN5_OUTPUT_TAG $MAIN5_OUTPUT_NEWTAG && true || false)"
 
           if $main1 && $pre1 && $main2 && $pre2 && $main3 && $main4 && $main5
           then

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
 - **CUSTOM_TAG** _(optional)_ - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
 - **SOURCE** _(optional)_ - Operate on a relative path under $GITHUB_WORKSPACE.
 - **DRY_RUN** _(optional)_ - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are `true` and `false` (default).
+- **GIT_API_TAGGING** _(optional)_ - Set if using git cli or git api calls for tag push operations. Possible values are `false` and `true` (default).
 - **INITIAL_VERSION** _(optional)_ - Set initial version before bump. Default `0.0.0`.
 - **TAG_CONTEXT** _(optional)_ - Set the context of the previous tag. Possible values are `repo` (default) or `branch`.
 - **PRERELEASE** _(optional)_ - Define if workflow runs in prerelease mode, `false` by default. Note this will be overwritten if using complex suffix release branches. Use it with checkout `ref: ${{ github.sha }}` for consistency see [issue 266](https://github.com/anothrNick/github-tag-action/issues/266).


### PR DESCRIPTION
Change git tag over http to git cli

Fixes: https://github.com/anothrNick/github-tag-action/actions/runs/3372412451/jobs/5595804270#step:4:89 

My availability to test this is low.
But is what we use to tag the major tag in here https://github.com/anothrNick/github-tag-action/blob/master/.github/workflows/main.yml#L36-L50

I don't see why not use the same approach everywhere instead of soft tags.

We might need to add more checks to this.
