### PR TITLE
Parse commit body

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -123,7 +123,7 @@ then
 fi
 
 # get the merge commit message looking for #bumps
-log=$(git show -s --format=%s)
+log=$(git show -s --format=%B)
 echo "Last commit message: $log"
 
 case "$log" in


### PR DESCRIPTION
Revert formatting change in ac1e937 which causes only the commit subject to be parsed. Fixes #213 

# Summary of changes

Do any of the followings changes break current behaviour or configuration?

- NO

## How changes have been tested

- Manual testing: I tested major, minor and default changes using both the commit head and body. No issues were observed.

## List any unknowns

- @sbe-arg was there a reason you chose %s over %B in ac1e937? Are there any side-effects of %B that we need to avoid?