### PR TITLE
Fix tag bumps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
-          ref: ${{ github.ref_name }}
 
       - name: version-tag
         id: tag


### PR DESCRIPTION
github.ref_name at checkout is limited within the same repo by default

Works when branches merged are from the same repo but breaks on forks due token permissions