### PR TITLE
Select last commit or full branch history for analysis of #bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.sha }}
         fetch-depth: '0'
 
     - name: Bump version and push tag
@@ -83,6 +83,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
 - **MINOR_STRING_TOKEN** _(optional)_ - Change the default `#minor` commit message string tag.
 - **PATCH_STRING_TOKEN** _(optional)_ - Change the default `#patch` commit message string tag.
 - **NONE_STRING_TOKEN** _(optional)_ - Change the default `#none` commit message string tag.
+- **BRANCH_HISTORY** _(optional)_ - Set the history of the branch for finding `#bumps`. Possible values `last` and `full` defaults to full history of the new branch.
 
 #### Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,13 +125,12 @@ then
 fi
 
 # get the merge commit message looking for #bumps
-if [ "$history" == 'last' ]
-then
-    log=$(git show -s --format=%B)
-else
-    log=$(git show -s --format=%B)
-fi
-echo "History: $log"
+declare -A history_type=( 
+    ["last"]="$(git show -s --format=%B)" \
+    ["full"]="$(git log master..HEAD --format=%B)" \
+)
+log=${history_type[${history}]}
+printf "History: \n%log" "$log"
 
 case "$log" in
     *$major_string_token* ) new=$(semver -i major "$tag"); part="major";;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ major_string_token=${MAJOR_STRING_TOKEN:-#major}
 minor_string_token=${MINOR_STRING_TOKEN:-#minor}
 patch_string_token=${PATCH_STRING_TOKEN:-#patch}
 none_string_token=${NONE_STRING_TOKEN:-#none}
+history=${HISTORY:-full}
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
 git config --global --add safe.directory /github/workspace
 
@@ -39,6 +40,7 @@ echo -e "\tMAJOR_STRING_TOKEN: ${major_string_token}"
 echo -e "\tMINOR_STRING_TOKEN: ${minor_string_token}"
 echo -e "\tPATCH_STRING_TOKEN: ${patch_string_token}"
 echo -e "\tNONE_STRING_TOKEN: ${none_string_token}"
+echo -e "\tHISTORY: ${history}"
 
 # verbose, show everything
 if $verbose
@@ -123,8 +125,13 @@ then
 fi
 
 # get the merge commit message looking for #bumps
-log=$(git show -s --format=%B)
-echo "Last commit message: $log"
+if [ "$history" == 'last' ]
+then
+    log=$(git show -s --format=%B)
+else
+    log=$(git show -s --format=%B)
+fi
+echo "History: $log"
 
 case "$log" in
     *$major_string_token* ) new=$(semver -i major "$tag"); part="major";;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ major_string_token=${MAJOR_STRING_TOKEN:-#major}
 minor_string_token=${MINOR_STRING_TOKEN:-#minor}
 patch_string_token=${PATCH_STRING_TOKEN:-#patch}
 none_string_token=${NONE_STRING_TOKEN:-#none}
-history=${HISTORY:-full}
+branch_history=${BRANCH_HISTORY:-full}
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
 git config --global --add safe.directory /github/workspace
 
@@ -40,7 +40,7 @@ echo -e "\tMAJOR_STRING_TOKEN: ${major_string_token}"
 echo -e "\tMINOR_STRING_TOKEN: ${minor_string_token}"
 echo -e "\tPATCH_STRING_TOKEN: ${patch_string_token}"
 echo -e "\tNONE_STRING_TOKEN: ${none_string_token}"
-echo -e "\tHISTORY: ${history}"
+echo -e "\tBRANCH_HISTORY: ${branch_history}"
 
 # verbose, show everything
 if $verbose
@@ -129,8 +129,8 @@ declare -A history_type=(
     ["last"]="$(git show -s --format=%B)" \
     ["full"]="$(git log master..HEAD --format=%B)" \
 )
-log=${history_type[${history}]}
-printf "History: \n%log" "$log"
+log=${history_type[${branch_history}]}
+printf "History:\n---\n%s\n---\n" "$log"
 
 case "$log" in
     *$major_string_token* ) new=$(semver -i major "$tag"); part="major";;


### PR DESCRIPTION
Variable BRANCH_HISTORY" `full|last` allows to select the length of the history for finding bump keywords.

As per examples:
```
history='full'
declare -A history_type=( 
    ["last"]="$(git show -s --format=%B)" \
    ["full"]="$(git log master..HEAD --format=%B)" \
)
log=${history_type[${history}]}
printf "History:\n---\n%s\n---\n" "$log"
History:
---
history type


POC log
---
```

```
history='last'
declare -A history_type=( 
    ["last"]="$(git show -s --format=%B)" \
    ["full"]="$(git log master..HEAD --format=%B)" \
)
log=${history_type[${history}]}
printf "History:\n---\n%s\n---\n" "$log"
History:
---
history type
---
```

fixes https://github.com/anothrNick/github-tag-action/issues/211 