### PR TITLE
Exit with error if default branch is not set in non prs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,6 +125,20 @@ then
     exit 0
 fi
 
+# sanitize that the default_branch is set (via env var when running on PRs) else find it natively
+if [ -z "${default_branch}" ]
+then
+    echo "The DEFAULT_BRANCH should be autodetected when tag-action runs on on PRs else must be defined, See: https://github.com/anothrNick/github-tag-action/pull/230, since is not defined we find it natively"
+    default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+    echo "DEFAULT_BRANCH=${default_branch}"
+    # re check this
+    if [ -z "${default_branch}" ]
+    then
+        echo "::error::DEFAULT_BRANCH must not be null, something has gone wrong."
+        exit 1
+    fi
+fi
+
 # get the merge commit message looking for #bumps
 declare -A history_type=( 
     ["last"]="$(git show -s --format=%B)" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -130,7 +130,7 @@ if [ -z "${default_branch}" ]
 then
     echo "The DEFAULT_BRANCH should be autodetected when tag-action runs on on PRs else must be defined, See: https://github.com/anothrNick/github-tag-action/pull/230, since is not defined we find it natively"
     default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
-    echo "DEFAULT_BRANCH=${default_branch}"
+    echo "default_branch=${default_branch}"
     # re check this
     if [ -z "${default_branch}" ]
     then


### PR DESCRIPTION
This not really a hotfix more like a user warning to set the default_branch if using a workflow approach that does not contemplate PRs.

Open question, do we want to try to identify if master or main exist and define that as default branch as workaround?