### PR TITLE
Hotfix - Add log compare as default instead of full log

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
 - **MINOR_STRING_TOKEN** _(optional)_ - Change the default `#minor` commit message string tag.
 - **PATCH_STRING_TOKEN** _(optional)_ - Change the default `#patch` commit message string tag.
 - **NONE_STRING_TOKEN** _(optional)_ - Change the default `#none` commit message string tag.
-- **BRANCH_HISTORY** _(optional)_ - Set the history of the branch for finding `#bumps`. Possible values `last` and `full` defaults to full history of the new branch.
+- **BRANCH_HISTORY** _(optional)_ - Set the history of the branch for finding `#bumps`. Possible values `last`, `full` and `compare` defaults to `compare`.
+  - `full`: attempt to show all history, does not work on rebase and squash due missing HEAD [should be deprecated in v2 is breaking many workflows]
+  - `last`: show the single last commit
+  - `compare`: show all commits since previous repo tag number
 
 #### Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ major_string_token=${MAJOR_STRING_TOKEN:-#major}
 minor_string_token=${MINOR_STRING_TOKEN:-#minor}
 patch_string_token=${PATCH_STRING_TOKEN:-#patch}
 none_string_token=${NONE_STRING_TOKEN:-#none}
-branch_history=${BRANCH_HISTORY:-last}
+branch_history=${BRANCH_HISTORY:-compare}
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
 git config --global --add safe.directory /github/workspace
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ major_string_token=${MAJOR_STRING_TOKEN:-#major}
 minor_string_token=${MINOR_STRING_TOKEN:-#minor}
 patch_string_token=${PATCH_STRING_TOKEN:-#patch}
 none_string_token=${NONE_STRING_TOKEN:-#none}
-branch_history=${BRANCH_HISTORY:-full}
+branch_history=${BRANCH_HISTORY:-last}
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
 git config --global --add safe.directory /github/workspace
 
@@ -143,6 +143,7 @@ fi
 declare -A history_type=( 
     ["last"]="$(git show -s --format=%B)" \
     ["full"]="$(git log "${default_branch}"..HEAD --format=%B)" \
+    ["compare"]="$(git log "${tag_commit}".."${commit}" --format=%B)" \
 )
 log=${history_type[${branch_history}]}
 printf "History:\n---\n%s\n---\n" "$log"


### PR DESCRIPTION
The current implementation of full git log breaks in squash and rebase due missing HEAD using suggestion from @jonavos here https://github.com/anothrNick/github-tag-action/issues/232#issuecomment-1372299198

Unsure how this will behave in pre-release re runs as the pre_tag_commit is not considered in this log capture. But thats another missing feature we can review this at another stage