### PR TITLE
Hotfix - Validate default_branch only when history type full

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
 
 - **GITHUB_TOKEN** **_(required)_** - Required for permission to tag the repo.
 - **DEFAULT_BUMP** _(optional)_ - Which type of bump to use when none explicitly provided (default: `minor`).
-- **DEFAULT_BRANCH** _(optional)_ - Overwrite the default branch its read from Github Runner env var but can be overwritten (default: `$GITHUB_BASE_REF`).
+- **DEFAULT_BRANCH** _(optional)_ - Overwrite the default branch its read from Github Runner env var but can be overwritten (default: `$GITHUB_BASE_REF`). Strongly recommended to set this var if using anything else than master or main as default branch otherwise in combination with history full will error.
 - **WITH_V** _(optional)_ - Tag version with `v` character.
 - **RELEASE_BRANCHES** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
 - **CUSTOM_TAG** _(optional)_ - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -126,7 +126,7 @@ then
 fi
 
 # sanitize that the default_branch is set (via env var when running on PRs) else find it natively
-if [ -z "${default_branch}" ] && [ "$history_type" == "full" ]
+if [ -z "${default_branch}" ] && [ "$branch_history" == "full" ]
 then
     echo "The DEFAULT_BRANCH should be autodetected when tag-action runs on on PRs else must be defined, See: https://github.com/anothrNick/github-tag-action/pull/230, since is not defined we find it natively"
     default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -126,7 +126,7 @@ then
 fi
 
 # sanitize that the default_branch is set (via env var when running on PRs) else find it natively
-if [ -z "${default_branch}" ]
+if [ -z "${default_branch}" ] && [ "$history_type" == "full" ]
 then
     echo "The DEFAULT_BRANCH should be autodetected when tag-action runs on on PRs else must be defined, See: https://github.com/anothrNick/github-tag-action/pull/230, since is not defined we find it natively"
     default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -129,7 +129,7 @@ fi
 if [ -z "${default_branch}" ] && [ "$branch_history" == "full" ]
 then
     echo "The DEFAULT_BRANCH should be autodetected when tag-action runs on on PRs else must be defined, See: https://github.com/anothrNick/github-tag-action/pull/230, since is not defined we find it natively"
-    default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+    default_branch=$(git branch -rl '*/master' '*/main' | cut -d / -f2)
     echo "default_branch=${default_branch}"
     # re check this
     if [ -z "${default_branch}" ]


### PR DESCRIPTION
As suggested by @vancejc-mt  in https://github.com/anothrNick/github-tag-action/issues/243 we should only validate the default_branch when history is set to full

some testing here fixing the HEAD symbolic issue https://github.com/anothrNick/github-tag-action/actions/runs/3854410905/jobs/6568375010#step:3:130 

Added warning to users in readme when combining history full and the default branch is something other than main or master.