### PR TITLE
When running 1.63 in a fresh repo without tags it fails to validate existing tags

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -113,7 +113,7 @@ then
 fi
 
 # get current commit hash for tag
-tag_commit=$(git rev-list -n 1 "$tag")
+tag_commit=$(git rev-list -n 1 "$tag" || true )
 # get current commit hash
 commit=$(git rev-parse HEAD)
 # skip if there are no new commits for non-pre_release


### PR DESCRIPTION
Testing ran here nothing else relevant was found 
https://github.com/sbe-arg/dummy-releases/actions 

@sammcj it's not urgent