### PR TITLE
remove -qs from pre release tag case

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,11 +82,11 @@ preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
 case "$tag_context" in
     *repo*) 
         tag="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | (grep -E "$tagFmt" || true) | head -n 1)"
-        pre_tag="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | (grep -qs -E "$preTagFmt" || true) | head -n 1)"
+        pre_tag="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | (grep -E "$preTagFmt" || true) | head -n 1)"
         ;;
     *branch*) 
         tag="$(git tag --list --merged HEAD --sort=-v:refname | (grep -E "$tagFmt" || true) | head -n 1)"
-        pre_tag="$(git tag --list --merged HEAD --sort=-v:refname | (grep -qs -E "$preTagFmt" || true) | head -n 1)"
+        pre_tag="$(git tag --list --merged HEAD --sort=-v:refname | (grep -E "$preTagFmt" || true) | head -n 1)"
         ;;
     * ) echo "Unrecognised context"
         exit 1;;


### PR DESCRIPTION
since we use || true there is no need for -s and -q results in an always null pretag var

this breaks some flows where we bump an existing pretag