### PR TITLE
Suddenly existing repos fail with missing permissions for token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
   bump-version:
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -242,6 +242,7 @@ fi
 git tag "$new"
 
 # push new tag ref to github
+# this needs permissions in the workflow as contents: write
 dt=$(date '+%Y-%m-%dT%H:%M:%SZ')
 full_name=$GITHUB_REPOSITORY
 git_refs_url=$(jq .repository.git_refs_url "$GITHUB_EVENT_PATH" | tr -d '"' | sed 's/{\/sha}//g')


### PR DESCRIPTION
Add permissions to actions token, errors here https://github.com/anothrNick/github-tag-action/actions/runs/5039598293/jobs/9037848230#step:4:265

Added a comment in entrypoint so merging this releases 1.66 as failed with permissions on https://github.com/anothrNick/github-tag-action/pull/270 (also we should consider adding releasing tags manually via workflow run)