### PR TITLE
Sorting tags based on commit date for branch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,10 +82,10 @@ preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
 git_refs=
 case "$tag_context" in
     *repo*)
-        git_refs=$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)')
+        git_refs=$(git for-each-ref --sort=-committerdate --format '%(refname:lstrip=2)')
         ;;
     *branch*)
-        git_refs=$(git tag --list --merged HEAD --sort=-v:refname)
+        git_refs=$(git tag --list --merged HEAD --sort=-committerdate)
         ;;
     * ) echo "Unrecognised context"
         exit 1;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,7 +82,7 @@ preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
 git_refs=
 case "$tag_context" in
     *repo*)
-        git_refs=$(git for-each-ref --sort=-committerdate --format '%(refname:lstrip=2)')
+        git_refs=$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)')
         ;;
     *branch*)
         git_refs=$(git tag --list --merged HEAD --sort=-committerdate)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). -->
# Summary of changes

Changed the sorting of tags for the branch context to be based on the latest committed tag rather than the latest 'v' tag. This is to solve an issue where we had older v tags before we migrated to no v. 

Without this change the last v tag is selected rather than the last tag which was causing an error. 

Prior sorting for branch context :
<img width="405" alt="Screenshot 2023-06-01 at 1 18 41 PM" src="https://github.com/anothrNick/github-tag-action/assets/37314336/381c9195-b3e6-4f42-a090-178283801f1d">

Proposed change in this PR:
<img width="757" alt="Screenshot 2023-06-01 at 1 19 18 PM" src="https://github.com/anothrNick/github-tag-action/assets/37314336/deae5dcd-2677-441a-8158-3328b53555b8">


## Breaking Changes

Not a breaking change

## How changes have been tested

- Tested in my repos and works as intended, the latest tag is at the top of the list rather than the latest "v" tag

## List any unknowns

- Why was there a sort on the 'v' rather than just latest tag as that was causing a failure on our repo that had older v tags before moving to no v
