### PR TITLE
Fixes #309

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
   - `last`: show the single last commit
   - `compare`: show all commits since previous repo tag number
 - **FORCE_WITHOUT_CHANGES** _(optional)_ - Enforce the brach creation even if there are no changes from the tag.
+- **FORCE_WITHOUT_CHANGES_PRE** _(optional)_ - Similar to force without changes, for pre-releases.
 
 ### Outputs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,7 @@ patch_string_token=${PATCH_STRING_TOKEN:-#patch}
 none_string_token=${NONE_STRING_TOKEN:-#none}
 branch_history=${BRANCH_HISTORY:-compare}
 force_without_changes=${FORCE_WITHOUT_CHANGES:-false}
+force_without_changes_pre=${FORCE_WITHOUT_CHANGES:-false}
 
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
 git config --global --add safe.directory /github/workspace
@@ -47,7 +48,8 @@ echo -e "\tMINOR_STRING_TOKEN: ${minor_string_token}"
 echo -e "\tPATCH_STRING_TOKEN: ${patch_string_token}"
 echo -e "\tNONE_STRING_TOKEN: ${none_string_token}"
 echo -e "\tBRANCH_HISTORY: ${branch_history}"
-echo -e "\tFORCE: ${force_without_changes}"
+echo -e "\tFORCE_WITHOUT_CHANGES: ${force_without_changes}"
+echo -e "\tFORCE_WITHOUT_CHANGES_PRE: ${force_without_changes_pre}"
 
 # verbose, show everything
 if $verbose
@@ -127,7 +129,7 @@ tag_commit=$(git rev-list -n 1 "$tag" || true )
 # get current commit hash
 commit=$(git rev-parse HEAD)
 # skip if there are no new commits for non-pre_release
-if [ "$tag_commit" == "$commit" ] && [ "$force_without_changes" == "false" ]
+if [ "$tag_commit" == "$commit" ] && [ "$force_without_changes" == "false" ] 
 then
     echo "No new commits since previous tag. Skipping..."
     setOutput "new_tag" "$tag"
@@ -190,7 +192,7 @@ then
     # get current commit hash for tag
     pre_tag_commit=$(git rev-list -n 1 "$pre_tag" || true)
     # skip if there are no new commits for pre_release
-    if [ "$pre_tag_commit" == "$commit" ]
+    if [ "$pre_tag_commit" == "$commit" ] &&  [ "$pre_force_without_changes" == "false" ] 
     then
         echo "No new commits since previous pre_tag. Skipping..."
         setOutput "new_tag" "$pre_tag"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). -->
# Summary of changes

<!--- Describe your changes -->

## Breaking Changes

NO

Since I added a new argument (FORCE_WITHOUT_CHANGES_PRE), there shouldn't be any.
Alternatively, we can use FORCE_WITHOUT_CHANGES for prereleases as well, which would imply a breaking change.

## How changes have been tested

I've tried the fork on a private repo. It works as expected. The changes are also minimal so they should be fine. 

![image](https://github.com/anothrNick/github-tag-action/assets/43417195/81255c38-dedf-43ca-b03a-79df7bb76904)


## List any unknowns


