### PR TITLE
Use pull_request_target event to run in base of pr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,15 @@
 name: Bump version
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:
       - master
     paths:
-      - 'entrypoint.sh'
-      - 'action.yml'
-      - 'Dockerfile'
+      - "entrypoint.sh"
+      - "action.yml"
+      - "Dockerfile"
 
 jobs:
   bump-version:
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
 
       - name: version-tag
         id: tag


### PR DESCRIPTION
# Summary of changes

Use `pull_request_target` event to run in base of pr (workflow yaml)

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

## Breaking Changes

Do any of the included changes break current behaviour or configuration?

NO

## How changes have been tested

-

## List any unknowns

-
