### PR TITLE
Fix Auto Releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,7 @@ jobs:
       - name: automatic-release
         uses: softprops/action-gh-release@v2.0.0
         with:
-#          draft: true # Can uncomment this if you want to keep it a draft, but I find it more useful to auto-publish the release on each PR merge.
           token: ${{ secrets.GITHUB_TOKEN }}
-#          name: "${{ steps.tag.outputs.tag }}: [title-edit-me] by:${{ github.actor }}" # Uncomment if you go the draft route, otherwise it defaults to the tag name (i.e. 1.67.0)
           tag_name: ${{ steps.tag.outputs.new_tag }}
           generate_release_notes: true
           prerelease: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,14 +30,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_API_TAGGING: false # uses git cli
 
-      # auto releases is not working atm and is deleting releases due branch tags
-      - name: automatic-draft-release
-        uses: marvinpinto/action-automatic-releases@v1.2.1
+      - name: automatic-release
+        uses: softprops/action-gh-release@v2.0.0
         with:
-          draft: true
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          title: "${{ steps.tag.outputs.tag }}: [title-edit-me] by:${{ github.actor }}"
-          automatic_release_tag: ${{ steps.tag.outputs.new_tag }}
+#          draft: true # Can uncomment this if you want to keep it a draft, but I find it more useful to auto-publish the release on each PR merge.
+          token: ${{ secrets.GITHUB_TOKEN }}
+#          name: "${{ steps.tag.outputs.tag }}: [title-edit-me] by:${{ github.actor }}" # Uncomment if you go the draft route, otherwise it defaults to the tag name (i.e. 1.67.0)
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          generate_release_notes: true
+          prerelease: false
 
       - name: version-tag-major
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 #          draft: true # Can uncomment this if you want to keep it a draft, but I find it more useful to auto-publish the release on each PR merge.
           token: ${{ secrets.GITHUB_TOKEN }}
 #          name: "${{ steps.tag.outputs.tag }}: [title-edit-me] by:${{ github.actor }}" # Uncomment if you go the draft route, otherwise it defaults to the tag name (i.e. 1.67.0)
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          tag_name: ${{ steps.tag.outputs.new_tag }}
           generate_release_notes: true
           prerelease: false
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,7 +104,7 @@ matching_pre_tag_refs=$( (grep -E "$preTagFmt" <<< "$git_refs") || true)
 tag=$(head -n 1 <<< "$matching_tag_refs")
 pre_tag=$(head -n 1 <<< "$matching_pre_tag_refs")
 
-# if there are none, start tags at INITIAL_VERSION
+# if there are none, start tags at initial version
 if [ -z "$tag" ]
 then
     if $with_v


### PR DESCRIPTION
# Summary of changes

Poking around in this repository, I saw your comment in your main workflow file that auto-release creation was broken. Seeing as I have auto-releases working splendidly for my organization, I figured I'd pass along my config if you were interested in using it.

Feel free to change/tweak/adjust whatever you like here, or to reject it entirely.  Completely up to you.

## Breaking Changes

NO

## How changes have been tested

Ran the workflow on my own forked repo [with success](https://github.com/gabriel-stackhouse/github-tag-action/releases/tag/0.1.0):

![image](https://github.com/anothrNick/github-tag-action/assets/45368106/cb66848b-bd58-49ea-9164-8f71471fb868)

## List any unknowns

N/A
