### PR TITLE
Fix Not tagging Non-Release branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
 - **DEFAULT_BUMP** _(optional)_ - Which type of bump to use when none explicitly provided (default: `minor`).
 - **DEFAULT_BRANCH** _(optional)_ - Overwrite the default branch its read from GitHub Runner env var but can be overwritten (default: `$GITHUB_BASE_REF`). Strongly recommended to set this var if using anything else than master or main as default branch otherwise in combination with history full will error.
 - **WITH_V** _(optional)_ - Tag version with `v` character.
-- **RELEASE_BRANCHES** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
+- **RELEASE_BRANCHES** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the branch name and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
 - **CUSTOM_TAG** _(optional)_ - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
 - **SOURCE** _(optional)_ - Operate on a relative path under $GITHUB_WORKSPACE.
 - **DRY_RUN** _(optional)_ - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are `true` and `false` (default).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -230,7 +230,7 @@ else
     fi
     if ! $release
     then
-      new="v${new}-${current_branch}"
+      new="${new}-${current_branch}"
     fi
     echo -e "Bumping tag ${tag} - New tag ${new}"
 fi


### PR DESCRIPTION
# Summary of changes

According to the documentation non-release "branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag."

This was not working correctly and tags were being created on all commits regardless of the branch being in `RELEASE_BRANCHES`.

This change disables tagging when it is a non-release branch. It also adds the branch name as a suffix instead of using the commit hash. 

## Breaking Changes

Do any of the included changes break current behavior or configuration?

**YES** for anyone relying on tagging for non-release branches.

## How changes have been tested

- I have tested this change in our local fork and other temporary repos against release and non-release branches. I did not test with all the other options. 
