### PR TITLE
Added TAG_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,15 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` or newer to be sure you ret
 - **GITHUB_TOKEN** **_(required)_** - Required for permission to tag the repo.
 - **DEFAULT_BUMP** _(optional)_ - Which type of bump to use when none explicitly provided (default: `minor`).
 - **DEFAULT_BRANCH** _(optional)_ - Overwrite the default branch its read from GitHub Runner env var but can be overwritten (default: `$GITHUB_BASE_REF`). Strongly recommended to set this var if using anything else than master or main as default branch otherwise in combination with history full will error.
-- **WITH_V** _(optional)_ - Tag version with `v` character.
+- **WITH_V** _(optional, depricated)_ - Tag version with `v` character. Replaced by TAG_PREFIX
 - **RELEASE_BRANCHES** _(optional)_ - Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master` ...
 - **CUSTOM_TAG** _(optional)_ - Set a custom tag, useful when generating tag based on f.ex FROM image in a docker image. **Setting this tag will invalidate any other settings set!**
 - **SOURCE** _(optional)_ - Operate on a relative path under $GITHUB_WORKSPACE.
 - **DRY_RUN** _(optional)_ - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are `true` and `false` (default).
 - **GIT_API_TAGGING** _(optional)_ - Set if using git cli or git api calls for tag push operations. Possible values are `false` and `true` (default).
-- **INITIAL_VERSION** _(optional)_ - Set initial version before bump. Default `0.0.0`. MAKE SURE NOT TO USE vX.X.X here if combined WITH_V
+- **INITIAL_VERSION** _(optional)_ - Set initial version before bump. Default `0.0.0`. MAKE SURE NOT TO USE vX.X.X here if combined TAG_PREFIX
 - **TAG_CONTEXT** _(optional)_ - Set the context of the previous tag. Possible values are `repo` (default) or `branch`.
+- **TAG_PREFIX** _(optional)_ - Prefix to add to the tag. eg `v` to create `v0.0.0`, WITH_V takes precidance for backwards compatibility
 - **PRERELEASE** _(optional)_ - Define if workflow runs in prerelease mode, `false` by default. Note this will be overwritten if using complex suffix release branches. Use it with checkout `ref: ${{ github.sha }}` for consistency see [issue 266](https://github.com/anothrNick/github-tag-action/issues/266).
 - **PRERELEASE_SUFFIX** _(optional)_ - Suffix for your prerelease versions, `beta` by default. Note this will only be used if a prerelease branch.
 - **VERBOSE** _(optional)_ - Print git logs. For some projects these logs may be very large. Possible values are `true` (default) and `false`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ dryrun=${DRY_RUN:-false}
 git_api_tagging=${GIT_API_TAGGING:-true}
 initial_version=${INITIAL_VERSION:-0.0.0}
 tag_context=${TAG_CONTEXT:-repo}
+tag_prefix=${TAG_PREFIX:-false}
 prerelease=${PRERELEASE:-false}
 suffix=${PRERELEASE_SUFFIX:-beta}
 verbose=${VERBOSE:-false}
@@ -40,6 +41,7 @@ echo -e "\tDRY_RUN: ${dryrun}"
 echo -e "\tGIT_API_TAGGING: ${git_api_tagging}"
 echo -e "\tINITIAL_VERSION: ${initial_version}"
 echo -e "\tTAG_CONTEXT: ${tag_context}"
+echo -e "\tTAG_PREFIX: ${tag_prefix}"
 echo -e "\tPRERELEASE: ${prerelease}"
 echo -e "\tPRERELEASE_SUFFIX: ${suffix}"
 echo -e "\tVERBOSE: ${verbose}"
@@ -82,8 +84,23 @@ echo "pre_release = $pre_release"
 # fetch tags
 git fetch --tags
 
-tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
-preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
+# Set no tag prefix (not even v)
+tagPrefix=""
+
+# If a tag_prefix is supplied use that
+if [[ "${tag_prefix}" != "false" ]]
+then
+  tagPrefix=$tag_prefix
+fi
+
+# with_v superseeds tag_prefix
+if $with_v
+then
+    tagPrefix="v"
+fi
+
+tagFmt="^$tagPrefix?[0-9]+\.[0-9]+\.[0-9]+$"
+preTagFmt="^$tagPrefix?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
 
 # get the git refs
 git_refs=
@@ -107,20 +124,10 @@ pre_tag=$(head -n 1 <<< "$matching_pre_tag_refs")
 # if there are none, start tags at initial version
 if [ -z "$tag" ]
 then
-    if $with_v
-    then
-        tag="v$initial_version"
-    else
-        tag="$initial_version"
-    fi
+    tag="$tagPrefix$initial_version"
     if [ -z "$pre_tag" ] && $pre_release
     then
-        if $with_v
-        then
-            pre_tag="v$initial_version"
-        else
-            pre_tag="$initial_version"
-        fi
+        pre_tag="$tagPrefix$initial_version"
     fi
 fi
 
@@ -129,7 +136,7 @@ tag_commit=$(git rev-list -n 1 "$tag" || true )
 # get current commit hash
 commit=$(git rev-parse HEAD)
 # skip if there are no new commits for non-pre_release
-if [ "$tag_commit" == "$commit" ] && [ "$force_without_changes" == "false" ] 
+if [ "$tag_commit" == "$commit" ] && [ "$force_without_changes" == "false" ]
 then
     echo "No new commits since previous tag. Skipping..."
     setOutput "new_tag" "$tag"
@@ -160,10 +167,11 @@ declare -A history_type=(
 log=${history_type[${branch_history}]}
 printf "History:\n---\n%s\n---\n" "$log"
 
+current_tag="$(echo ${tag}| sed "s/${tagPrefix}//g")"
 case "$log" in
-    *$major_string_token* ) new=$(semver -i major "$tag"); part="major";;
-    *$minor_string_token* ) new=$(semver -i minor "$tag"); part="minor";;
-    *$patch_string_token* ) new=$(semver -i patch "$tag"); part="patch";;
+    *$major_string_token* ) new=${tagPrefix}$(semver -i major "${current_tag}"); part="major";;
+    *$minor_string_token* ) new=${tagPrefix}$(semver -i minor "${current_tag}"); part="minor";;
+    *$patch_string_token* ) new=${tagPrefix}$(semver -i patch "${current_tag}"); part="patch";;
     *$none_string_token* )
         echo "Default bump was set to none. Skipping..."
         setOutput "old_tag" "$tag"
@@ -181,7 +189,7 @@ case "$log" in
             setOutput "part" "$default_semvar_bump"
             exit 0
         else
-            new=$(semver -i "${default_semvar_bump}" "$tag")
+            new=${tagPrefix}$(semver -i "${default_semvar_bump}" "${current_tag}")
             part=$default_semvar_bump
         fi
         ;;
@@ -192,7 +200,7 @@ then
     # get current commit hash for tag
     pre_tag_commit=$(git rev-list -n 1 "$pre_tag" || true)
     # skip if there are no new commits for pre_release
-    if [ "$pre_tag_commit" == "$commit" ] &&  [ "$force_without_changes_pre" == "false" ] 
+    if [ "$pre_tag_commit" == "$commit" ] &&  [ "$force_without_changes_pre" == "false" ]
     then
         echo "No new commits since previous pre_tag. Skipping..."
         setOutput "new_tag" "$pre_tag"
@@ -202,28 +210,14 @@ then
     # already a pre-release available, bump it
     if [[ "$pre_tag" =~ $new ]] && [[ "$pre_tag" =~ $suffix ]]
     then
-        if $with_v
-        then
-            new=v$(semver -i prerelease "${pre_tag}" --preid "${suffix}")
-        else
-            new=$(semver -i prerelease "${pre_tag}" --preid "${suffix}")
-        fi
+        new=${tagPrefix}$(semver -i prerelease "${pre_tag}" --preid "${suffix}")
         echo -e "Bumping ${suffix} pre-tag ${pre_tag}. New pre-tag ${new}"
     else
-        if $with_v
-        then
-            new="v$new-$suffix.0"
-        else
-            new="$new-$suffix.0"
-        fi
+        new="${tagPrefix}${new}-${suffix}.0"
         echo -e "Setting ${suffix} pre-tag ${pre_tag} - With pre-tag ${new}"
     fi
     part="pre-$part"
 else
-    if $with_v
-    then
-        new="v$new"
-    fi
     echo -e "Bumping tag ${tag} - New tag ${new}"
 fi
 


### PR DESCRIPTION
# Summary of changes

Added `TAG_PREFIX` to replace `WITH_V`. `WITH_V` is still in place for backwards comparability, but the idea is it would be removed in a few versions (gives people a chance to change their code, doesn't force a major etc) 

This should fix https://github.com/anothrNick/github-tag-action/issues/320. I have a similar use case where a monorepo has a bunch of folders which maintain independent versions  

## Breaking Changes

Do any of the included changes break current behaviour or configuration?

NO : The changes are backwards compatible to allow a smoother transition

## How changes have been tested

[happy path in a pair of github repo's](https://github.com/timothyclarke/Merge_action_test/actions/runs/10890819327)

I've only tested the happy path so far

## List any unknowns

-
