### PR TITLE
Add git-lfs to installed packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL "repository"="https://github.com/anothrNick/github-tag-action"
 LABEL "homepage"="https://github.com/anothrNick/github-tag-action"
 LABEL "maintainer"="Nick Sjostrom"
 
-RUN apk --no-cache add bash git curl jq && npm install -g semver
+RUN apk --no-cache add bash git git-lfs curl jq && npm install -g semver
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
# Summary of changes
I use Git LFS to track large files that seldomly change.
Git LFS adds some hooks to call into the `git-lfs` command.
However, this command is not installed in the Docker image produced by the action, so the entire action fails.

## Alternative workarounds
Adding the following step before github-tag-action can be used to circumvent the missing dependency:

```yaml
- name: Delete .git/hooks/*
  run: rm -rf .git/hooks/*
```

## Breaking Changes
Do any of the included changes break current behaviour or configuration?

I believe not, since `git-lfs` is only invoked if its hooks are enabled.

## How changes have been tested
Docker build:

```bash
$ docker build --progress plain --no-cache .
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 370B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/node:20-alpine
#2 DONE 0.4s

#3 [internal] load .dockerignore
#3 transferring context: 2B done
#3 DONE 0.0s

#4 [1/3] FROM docker.io/library/node:20-alpine@sha256:c13b26e7e602ef2f1074aef304ce6e9b7dd284c419b35d89fcf3cc8e44a8def9
#4 CACHED

#5 [internal] load build context
#5 transferring context: 35B done
#5 DONE 0.0s

#6 [2/3] RUN apk --no-cache add bash git git-lfs curl jq && npm install -g semver
#6 0.253 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz
#6 0.352 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz
#6 0.560 (1/21) Installing ncurses-terminfo-base (6.4_p20240420-r1)
#6 0.566 (2/21) Installing libncursesw (6.4_p20240420-r1)
#6 0.572 (3/21) Installing readline (8.2.10-r0)
#6 0.577 (4/21) Installing bash (5.2.26-r0)
#6 0.589 Executing bash-5.2.26-r0.post-install
#6 0.593 (5/21) Installing ca-certificates (20240705-r0)
#6 0.612 (6/21) Installing brotli-libs (1.1.0-r2)
#6 0.621 (7/21) Installing c-ares (1.33.1-r0)
#6 0.624 (8/21) Installing libunistring (1.2-r0)
#6 0.636 (9/21) Installing libidn2 (2.3.7-r0)
#6 0.640 (10/21) Installing nghttp2-libs (1.62.1-r0)
#6 0.644 (11/21) Installing libpsl (0.21.5-r1)
#6 0.647 (12/21) Installing zstd-libs (1.5.6-r0)
#6 0.659 (13/21) Installing libcurl (8.10.1-r0)
#6 0.671 (14/21) Installing curl (8.10.1-r0)
#6 0.677 (15/21) Installing libexpat (2.6.3-r0)
#6 0.681 (16/21) Installing pcre2 (10.43-r0)
#6 0.693 (17/21) Installing git (2.45.2-r0)
#6 0.759 (18/21) Installing git-init-template (2.45.2-r0)
#6 0.762 (19/21) Installing git-lfs (3.5.1-r4)
#6 0.826 Executing git-lfs-3.5.1-r4.post-install
#6 0.855 Git LFS initialized.
#6 0.857 (20/21) Installing oniguruma (6.9.9-r0)
#6 0.864 (21/21) Installing jq (1.7.1-r0)
#6 0.872 Executing busybox-1.36.1-r29.trigger
#6 0.880 Executing ca-certificates-20240705-r0.trigger
#6 0.943 OK: 39 MiB in 37 packages
#6 1.572 
#6 1.572 added 1 package in 473ms
#6 1.573 npm notice
#6 1.573 npm notice New minor version of npm available! 10.8.2 -> 10.9.0
#6 1.573 npm notice Changelog: https://github.com/npm/cli/releases/tag/v10.9.0
#6 1.573 npm notice To update run: npm install -g npm@10.9.0
#6 1.573 npm notice
#6 DONE 1.7s

#7 [3/3] COPY entrypoint.sh /entrypoint.sh
#7 DONE 0.0s

#8 exporting to image
#8 exporting layers
#8 exporting layers 0.1s done
#8 writing image sha256:964ed379a49d8b20fec026928e09f8f11d6c5b9ea1d8e9174a7deb15266627a1 done
#8 DONE 0.1s
```

Also, the forked action was run in a private repository, where Git LFS is configured. See log extracts below.

### Output before changes
```
<MORE LOGS HERE, mostly containing the PR commit message...>
EVENT: pushing tag 0.3.0 to origin
\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n
error: failed to push some refs to 'https://github.com/<user>/<repo>
```

### Output using this PR
```
EVENT: pushing tag 0.3.0 to origin
To https://github.com/<user>/<repo>
 * [new tag]         0.3.0 -> 0.3.0
```
