### PR TITLE
Bugfix for duplicate prefix on first prerelease tag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -219,7 +219,7 @@ then
         new=${tagPrefix}$(semver -i prerelease "${pre_tag}" --preid "${suffix}")
         echo -e "Bumping ${suffix} pre-tag ${pre_tag}. New pre-tag ${new}"
     else
-        new="${tagPrefix}${new}-${suffix}.0"
+        new="${new}-${suffix}.0"
         echo -e "Setting ${suffix} pre-tag ${pre_tag} - With pre-tag ${new}"
     fi
     part="pre-$part"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). -->
# Summary of changes
Removed the `tagPrefix` from the new tag when creating a `.0` prerelease tag. The prefix already gets added to the `new` variable at lines 178 to 198.
This should fix a bug that was introduced in PR #326 
<!--- Describe your changes -->

## Breaking Changes

Do any of the included changes break current behaviour or configuration?

NO

## How changes have been tested

-

## List any unknowns

-
