### PR TITLE
fix(tag list): change sorting to avoid bug

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -110,7 +110,7 @@ case "$tag_context" in
         git_refs=$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)')
         ;;
     *branch*)
-        git_refs=$(git tag --list --merged HEAD --sort=-committerdate)
+        git_refs=$(git tag --list --merged HEAD --sort=committerdate)
         ;;
     * ) echo "Unrecognised context"
         exit 1;;
@@ -119,8 +119,8 @@ esac
 # get the latest tag that looks like a semver (with or without v)
 matching_tag_refs=$( (grep -E "$tagFmt" <<< "$git_refs") || true)
 matching_pre_tag_refs=$( (grep -E "$preTagFmt" <<< "$git_refs") || true)
-tag=$(head -n 1 <<< "$matching_tag_refs")
-pre_tag=$(head -n 1 <<< "$matching_pre_tag_refs")
+tag=$(tail -n 1 <<< "$matching_tag_refs")
+pre_tag=$(tail -n 1 <<< "$matching_pre_tag_refs")
 
 # if there are none, start tags at initial version
 if [ -z "$tag" ]


### PR DESCRIPTION
# Summary of changes

When there are several tags on one commit, the tags with common commit arrive in the opposite order when using `sort=-committerdate`. When using `sort=committerdate`, the latest tag is at the bottom of the list, but the tags arrive in the correct order, even when there are several tags on one commit.

This pull request solves #345.

For instance, with the following git log:

```txt
commit abc123 (tag: v0.0.3, tag: v0.0.2, master)
Author: github-author
Date:   Wed Jul 23 16:24:51 2025 +0200

    Commit message 2

commit xyz789 (tag: v0.0.1)
Author: github-author
Date:   Wed Jul 23 16:05:26 2025 +0200

    Commit message 1
```

The command `git tag --list --sort=-committerdate` will yield:

```txt
v0.0.2
v0.0.3
v0.0.1
```

And the action will try to bump from v0.0.2. However, the command `git tag --list --sort=committerdate` will yield:

```text
v0.0.1
v0.0.2
v0.0.3
```
Which will, in combination with `tail -n 1` instead of `head -n 1`, make the action bump from v0.0.3

## Breaking Changes

Do any of the included changes break current behavior or configuration?

NO

## How changes have been tested

Yes

## List any unknowns
 
None known.