### PR TITLE
Support Escapable Characters in Prefix With BATs Testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,3 +202,31 @@ jobs:
             exit 1
           fi
 
+  test-bats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: '0'
+
+      - name: Install Dependencies
+        run: npm install -g semver
+
+      - name: Setup Bats
+        id: setup-bats
+        uses: bats-core/bats-action@3.0.1
+        with:
+          support-path: "${{ github.workspace }}/tests/bats-support"
+          assert-path: "${{ github.workspace }}/tests/bats-assert"
+          detik-install: false
+          file-install: false
+
+      - name: Run tests
+        shell: bash
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+        run: |
+          echo "Prefix Tests:"
+          bats test/test_prefix.bats 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# macOS
+.DS_Store
+
+# VSCode
+.vscode/
+
+# Rider/JetBrains IDE
+.idea/
+*.sln.iml
+*.user
+*.suo
+*.sln.docstates
+.idea_modules/
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -172,7 +172,7 @@ if [ -z "$tagPrefix" ]
 then
   current_tag=${tag}
 else
-  current_tag="$(echo ${tag}| sed "s/${tagPrefix}//g")"
+  current_tag="$(echo ${tag}| sed "s;${tagPrefix};;g")"
 fi
 case "$log" in
     *$major_string_token* ) new=${tagPrefix}$(semver -i major "${current_tag}"); part="major";;

--- a/test/test_prefix.bats
+++ b/test/test_prefix.bats
@@ -49,3 +49,32 @@ run_entry() {
   assert_line "Bumping tag 1.0.0 - New tag 1.1.0"
 }
 
+@test "Creates a new tag with 'v' prefix" {
+  # Arrange
+  export SOURCE="$SOURCE"
+  export DRY_RUN="true"
+  export TAG_PREFIX="v"
+
+  # Act
+  run run_entry
+
+  # Assert
+  assert_success
+  assert_line "Bumping tag v0.0.0 - New tag v0.1.0"
+}
+
+@test "Bumps a tag with 'v' prefix" {
+  # Arrange
+  export SOURCE="$SOURCE"
+  export DRY_RUN="true"
+  export TAG_PREFIX="v"
+  git tag "v1.0.0" && git commit -m "bump" --allow-empty >/dev/null
+
+  # Act
+  run run_entry
+
+  # Assert
+  assert_success
+  assert_line "Bumping tag v1.0.0 - New tag v1.1.0"
+}
+

--- a/test/test_prefix.bats
+++ b/test/test_prefix.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+export BATS_LIB_PATH=${BATS_LIB_PATH:-"/usr/lib"}
+bats_load_library bats-support
+bats_load_library bats-assert
+
+setup() {
+  TMP=$(mktemp -d)
+  cd "$TMP"
+  git init -b main >/dev/null
+  git config user.name "Test"
+  git config user.email "test@example.com"
+  touch README && git add README && git commit -m "initial" >/dev/null
+
+  SOURCE="../../../../..$(pwd)" # Workaround for "GITHUB_WORKSPACE" prefix in script
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+run_entry() {
+  bash "$BATS_TEST_DIRNAME/../entrypoint.sh"
+}
+
+@test "Creates a new tag with default settings (no prefix)" {
+  # Arrange
+  export SOURCE="$SOURCE"
+  export DRY_RUN="true"
+
+  # Act
+  run run_entry
+
+  # Assert
+  assert_success
+  assert_line "Bumping tag 0.0.0 - New tag 0.1.0"
+}
+
+@test "Bumps a tag with default settings (no prefix)" {
+  # Arrange
+  export SOURCE="$SOURCE"
+  export DRY_RUN="true"
+  git tag "1.0.0" && git commit -m "bump" --allow-empty >/dev/null
+
+  # Act
+  run run_entry
+
+  # Assert
+  assert_success
+  assert_line "Bumping tag 1.0.0 - New tag 1.1.0"
+}
+

--- a/test/test_prefix.bats
+++ b/test/test_prefix.bats
@@ -78,3 +78,49 @@ run_entry() {
   assert_line "Bumping tag v1.0.0 - New tag v1.1.0"
 }
 
+@test "Creates a new tag with '/' prefix" {
+  # Arrange
+  export SOURCE="$SOURCE"
+  export DRY_RUN="true"
+  export TAG_PREFIX="infra/"
+
+  # Act
+  run run_entry
+
+  # Assert
+  assert_success
+  assert_line "Bumping tag infra/0.0.0 - New tag infra/0.1.0"
+}
+
+@test "Bumps a tag with '/' prefix" {
+  # Arrange
+  export SOURCE="$SOURCE"
+  export DRY_RUN="true"
+  export TAG_PREFIX="infra/"
+  git tag "infra/1.0.0" && git commit -m "bump" --allow-empty >/dev/null
+
+  # Act
+  run run_entry
+
+  # Assert
+  assert_success
+  assert_line "Bumping tag infra/1.0.0 - New tag infra/1.1.0"
+}
+
+@test "Bumps only matching prefix tag" {
+  # Arrange
+  export SOURCE="$SOURCE"
+  export DRY_RUN="true"
+  export TAG_PREFIX="infra/"
+  git tag "2.0.0" && git commit -m "bump-no-prefix-1" --allow-empty >/dev/null
+  git tag "infra/1.7.0" && git commit -m "bump-prefix-1" --allow-empty >/dev/null
+  git tag "2.1.0" && git commit -m "bump-no-prefix-2" --allow-empty >/dev/null
+
+  # Act
+  run run_entry
+
+  # Assert
+  assert_success
+  assert_line "Bumping tag infra/1.7.0 - New tag infra/1.8.0"
+  refute_line "Bumping tag 2.1.0 - New tag 2.2.0"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). -->
# Summary of changes

As outlined in this ticket (https://github.com/anothrNick/github-tag-action/issues/342) forward slash is not supported for prefixes because of a conflict with `sed`. Forward slash in particular is common in tagging especially in a monorepo with multiple deployable entities.

I've updated the `sed` command to use semicolon `;` as a separator to support the large majority of use cases.

In this change I have also introduced a new test framework for the project [BATs](https://github.com/bats-core/bats-core) to support testing this change. The penultimate commit pushed the tests that verified that the `/` was not supported in a prefix, and the last commit actually fixed it (making the tests pass).

To support testing these particular changes and to avoid too much setup, I've passed in the `DRY_RUN` flag which allows us to test the functionality we need, however in future tests (if you decide to adopt this approach) it can be omited and committed to a repo.

## Breaking Changes

Do any of the included changes break current behaviour or configuration?

* NO

## How changes have been tested

* [Unit Test with BATs](https://github.com/TheYorkshireDev/github-tag-action/actions/runs/16617400092/job/47013190092?pr=1) (my fork):
  * Backward compatibility for no prefix
  * Backward compatibility for v prefix
  * Verified tag with `/` is parsed and bumped
* Verified that a tag (`test/`) is incremented using this change:
  * [Current version - failing](https://github.com/TheYorkshireDev/github-tag-action/actions/runs/16617400074/job/47013190072?pr=1)
  * [PR version - passing](https://github.com/TheYorkshireDev/github-tag-action/actions/runs/16617400074/job/47013190130?pr=1)

## List any unknowns

- 
