### PR TITLE
on multiple tags on the same commit, take the highest one

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,8 +119,9 @@ esac
 # get the latest tag that looks like a semver (with or without v)
 matching_tag_refs=$( (grep -E "$tagFmt" <<< "$git_refs") || true)
 matching_pre_tag_refs=$( (grep -E "$preTagFmt" <<< "$git_refs") || true)
-tag=$(head -n 1 <<< "$matching_tag_refs")
-pre_tag=$(head -n 1 <<< "$matching_pre_tag_refs")
+# Sort matching tags by version to ensure we get the highest version when multiple tags exist on same commit
+tag=$(echo "$matching_tag_refs" | sort -V | tail -n 1)
+pre_tag=$(echo "$matching_pre_tag_refs" | sort -V | tail -n 1)
 
 # if there are none, start tags at initial version
 if [ -z "$tag" ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). -->
# Summary of changes

When multiple tags exists for the latest version, choose the highest instead of the first. 

If user sets FORCE_WITHOUT_CHANGES: true and TAG_CONTEXT: branch, this creates a situation that if a commit has 2 tags, the next run (whether with or without changes) will collide with the previous tag 

## Breaking Changes

Do any of the included changes break current behaviour or configuration?

No

## How changes have been tested

On a private repo, the change fixed the issue. I will note that anyway, it replaces the head -n1, so it only relevant when there are multiple tags on the same commit
-

## List any unknowns

-
