### PR TITLE
make safe directory configurable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ force_without_changes_pre=${FORCE_WITHOUT_CHANGES:-false}
 tag_message=${TAG_MESSAGE:-""}
 
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
-git config --global --add safe.directory /github/workspace
+git config --global --add safe.directory "$(dirname "${GITHUB_WORKSPACE}")/*"
 
 cd "${GITHUB_WORKSPACE}/${source}" || exit 1
 


### PR DESCRIPTION
Currently, the code just sets `/github/workspace` (hardcoded) as "safe" git directory. I'm using the action in a non-github CI pipeline (forgejo) and I'm getting the error

```
fatal: detected dubious ownership in repository at '/workspace/waldner/cert-manager-webhook-he'
To add an exception for this directory, call:
	git config --global --add safe.directory /workspace/waldner/cert-manager-webhook-he
```

So I'm submitting this PR with a proposal to make that directory configurable using `SAFE_DIRECTORY` (the default, of course, still being `/github/workspace`).