### PR TITLE
fix(tag-action): strip prefix from pre_tag before semver operation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -213,10 +213,17 @@ then
         setOutput "tag" "$pre_tag"
         exit 0
     fi
+    # strip tag prefix from pre_tag for semver operations (same as current_tag)
+    if [ -z "$tagPrefix" ]
+    then
+      current_pre_tag=${pre_tag}
+    else
+      current_pre_tag="$(echo ${pre_tag}| sed "s;${tagPrefix};;g")"
+    fi
     # already a pre-release available, bump it
     if [[ "$pre_tag" =~ $new ]] && [[ "$pre_tag" =~ $suffix ]]
     then
-        new=${tagPrefix}$(semver -i prerelease "${pre_tag}" --preid "${suffix}")
+        new=${tagPrefix}$(semver -i prerelease "${current_pre_tag}" --preid "${suffix}")
         echo -e "Bumping ${suffix} pre-tag ${pre_tag}. New pre-tag ${new}"
     else
         new="${new}-${suffix}.0"


### PR DESCRIPTION
# Summary of changes

Fix semver parsing error when bumping prerelease tags on feature branches with tag prefixes.

**Problem:**
When bumping an existing prerelease tag on feature branches, the script was passing `pre_tag` (e.g., `"customprefix0.3.3-feature-super.1"`) directly to `semver -i prerelease`, which failed because semver cannot parse version strings with non-standard prefixes like `"customprefix"`.

**Solution:**
Strip the tag prefix from `pre_tag` before passing it to semver, matching the existing pattern used for `current_tag` (lines 171-176). The prefix is then added back to the semver result, ensuring the final tag maintains the correct format.

**Changes:**
- Added prefix stripping logic for `pre_tag` (lines 216-222), mirroring the `current_tag` handling
- Updated semver command on line 226 to use `current_pre_tag` (without prefix) instead of `pre_tag` (with prefix)

**Example:**
- Before: `semver -i prerelease "customprefix0.3.3-feature-super.1" --preid "feature-super"` ❌ (fails)
- After: `semver -i prerelease "0.3.3-feature-super.1" --preid "feature-super"` ✅ (works, then prefix added back)

## Breaking Changes

Do any of the included changes break current behaviour or configuration?

**NO**

This is a bug fix that maintains backward compatibility. The behavior for:
- Main/release branches: Unchanged (prerelease block is skipped)
- Feature branches without existing prerelease tags: Unchanged (goes to else branch, creates new `.0` tag)
- Feature branches with existing prerelease tags: **Fixed** (now correctly bumps prerelease number instead of failing)

## How changes have been tested

- **Logic verification:** Traced through the code flow for both main and feature branch scenarios
- **Edge cases verified:**
  - Empty `tagPrefix`: Handled correctly (no prefix stripping needed)
  - Empty `pre_tag`: Handled correctly (condition evaluates to false, goes to else branch)
  - Regex condition: Still uses original `pre_tag` with prefix (correct, since `$new` also has prefix)
- **Pattern consistency:** Matches existing `current_tag` prefix stripping pattern (lines 171-176)
- **Manual testing:** Simulated the fix with example values to verify semver command format

## List any unknowns

- None identified. The fix follows the exact same pattern already used successfully for `current_tag` prefix stripping, ensuring consistency and reliability.